### PR TITLE
Update to WildFly 21.0.0.Final, enhanced checklist in readme

### DIFF
--- a/wildfly-jakartaee-ear-archetype/README.adoc
+++ b/wildfly-jakartaee-ear-archetype/README.adoc
@@ -16,6 +16,7 @@ In file "pom.xml":
 * update to latest "org.jboss:jboss-parent" version found at https://repo.maven.apache.org/maven2/org/jboss/jboss-parent/
 
 In file "src/main/resources/archetype-resources/pom.xml":
+
 * update the version property named "version.jboss.bom"
 * check whether dependencies have changed.
 * check the plugin versions and update if necessary:
@@ -42,5 +43,5 @@ It will be installed to your local maven repository at "%USERHOME%/.m2/repositor
 ==== Create project from archetype
 To create a new project from this archetype, use this maven command (replace dummy values for "groupId", "artifactId" and "version" with correct values):
 ----
-$ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sample-jakartaee-ear-archetype -Dversion=1.0-SNAPSHOT -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-ear-archetype -DarchetypeVersion=21.0.0.Beta1-SNAPSHOT
+$ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sample-jakartaee-ear-archetype -Dversion=1.0-SNAPSHOT -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-ear-archetype -DarchetypeVersion=21.0.0.Final-SNAPSHOT
 ----

--- a/wildfly-jakartaee-ear-archetype/README.adoc
+++ b/wildfly-jakartaee-ear-archetype/README.adoc
@@ -10,8 +10,22 @@ More details can be found in the file "src/main/resources/archetype-resources/RE
 
 [[newwildflyversion]]
 ==== New WildFly version
-To update this archetype to a new WildFly version, just update the version property named "version.jboss.bom", found in "src/main/resources/archetype-resources/pom.xml".
-Check whether dependencies have changed.
+To update this archetype to a new WildFly version:
+In file "pom.xml":
+* update the version
+* update to latest "org.jboss:jboss-parent" version found at https://repo.maven.apache.org/maven2/org/jboss/jboss-parent/
+
+In file "src/main/resources/archetype-resources/pom.xml":
+* update the version property named "version.jboss.bom"
+* check whether dependencies have changed.
+* check the plugin versions and update if necessary:
+** wildfly-maven-plugin: https://repo.maven.apache.org/maven2/org/wildfly/plugins/wildfly-maven-plugin/
+** maven-compiler-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/
+** maven-ear-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-ear-plugin/
+** maven-ejb-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-ejb-plugin/
+** maven-surefire-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/
+** maven-failsafe-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-failsafe-plugin/
+** maven-war-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-war-plugin/
 
 Also test whether the Arquillian unit test "SampleIT" still works. Test it using both profiles "arq-remote" and "arq-managed".
 

--- a/wildfly-jakartaee-ear-archetype/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/pom.xml
@@ -13,14 +13,14 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>36</version>
+        <version>37</version>
         <relativePath />
     </parent>
 	
 
     <groupId>org.wildfly.archetype</groupId>
     <artifactId>wildfly-jakartaee-ear-archetype</artifactId>
-    <version>21.0.0.Beta1-SNAPSHOT</version>
+    <version>21.0.0.Final-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
 
     <name>WildFly Archetypes: Jakarta EE EAR Webapp</name>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
@@ -43,21 +43,21 @@
         <version.wildfly.maven.plugin>2.0.2.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>21.0.0.Beta1-SNAPSHOT</version.jboss.bom>
+        <version.jboss.bom>21.0.0.Final</version.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.ear.plugin>3.0.2</version.ear.plugin>
-        <version.ejb.plugin>3.0.1</version.ejb.plugin>
+        <version.ejb.plugin>3.1.0</version.ejb.plugin>
         <version.surefire.plugin>2.22.2</version.surefire.plugin>
         <version.failsafe.plugin>2.22.2</version.failsafe.plugin>
-        <version.war.plugin>3.2.3</version.war.plugin>
+        <version.war.plugin>3.3.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
-    
+
     <dependencyManagement>
         <dependencies>
 
@@ -120,7 +120,6 @@
             </plugin>
         </plugins>
     </build>
-
 
     <profiles>
         <profile>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
@@ -58,6 +58,24 @@
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
 
+    <!--This repository is required to resolve the WildFly 21.0.0 dependency "org.picketbox:picketbox:jar:5.0.3.Final-redhat-00006" -->
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+            <id>jboss-enterprise-maven-repository</id>
+            <name>JBoss Enterprise Maven Repository</name>
+            <url>https://maven.repository.redhat.com/ga/</url>
+        </repository>
+    </repositories>
+	
+	
     <dependencyManagement>
         <dependencies>
 

--- a/wildfly-jakartaee-webapp-archetype/README.adoc
+++ b/wildfly-jakartaee-webapp-archetype/README.adoc
@@ -10,8 +10,20 @@ More details can be found in the file "src/main/resources/archetype-resources/RE
 
 [[newwildflyversion]]
 ==== New WildFly version
-To update this archetype to a new WildFly version, just update the version property named "version.jboss.bom", found in "src/main/resources/archetype-resources/pom.xml".
-Check whether dependencies have changed.
+To update this archetype to a new WildFly version:
+In file "pom.xml":
+* update the version
+* update to latest "org.jboss:jboss-parent" version found at https://repo.maven.apache.org/maven2/org/jboss/jboss-parent/
+
+In file "src/main/resources/archetype-resources/pom.xml":
+* update the version property named "version.jboss.bom"
+* check whether dependencies have changed.
+* check the plugin versions and update if necessary:
+** wildfly-maven-plugin: https://repo.maven.apache.org/maven2/org/wildfly/plugins/wildfly-maven-plugin/
+** maven-compiler-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/
+** maven-surefire-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/
+** maven-failsafe-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-failsafe-plugin/
+** maven-war-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-war-plugin/
 
 Also test whether the Arquillian unit test "SampleIT" still works. Test it using both profiles "arq-remote" and "arq-managed".
 

--- a/wildfly-jakartaee-webapp-archetype/README.adoc
+++ b/wildfly-jakartaee-webapp-archetype/README.adoc
@@ -16,6 +16,7 @@ In file "pom.xml":
 * update to latest "org.jboss:jboss-parent" version found at https://repo.maven.apache.org/maven2/org/jboss/jboss-parent/
 
 In file "src/main/resources/archetype-resources/pom.xml":
+
 * update the version property named "version.jboss.bom"
 * check whether dependencies have changed.
 * check the plugin versions and update if necessary:
@@ -40,5 +41,5 @@ It will be installed to your local maven repository at "%USERHOME%/.m2/repositor
 ==== Create project from archetype
 To create a new project from this archetype, use this maven command (replace dummy values for "groupId", "artifactId" and "version" with correct values):
 ----
-$ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sampleproject -Dversion=1.0-SNAPSHOT -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-webapp-archetype -DarchetypeVersion=21.0.0.Beta1-SNAPSHOT
+$ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sampleproject -Dversion=1.0-SNAPSHOT -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-webapp-archetype -DarchetypeVersion=21.0.0.Final-SNAPSHOT
 ----

--- a/wildfly-jakartaee-webapp-archetype/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/pom.xml
@@ -13,14 +13,14 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>36</version>
+        <version>37</version>
         <relativePath />
     </parent>
 	
 
     <groupId>org.wildfly.archetype</groupId>
     <artifactId>wildfly-jakartaee-webapp-archetype</artifactId>
-    <version>21.0.0.Beta1-SNAPSHOT</version>
+    <version>21.0.0.Final-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
 
     <name>WildFly Archetypes: Jakarta EE Webapp</name>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -50,6 +50,23 @@
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
 
+    <!--This repository is required to resolve the WildFly 21.0.0 dependency "org.picketbox:picketbox:jar:5.0.3.Final-redhat-00006" -->
+    <repositories>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>never</updatePolicy>
+            </snapshots>
+            <id>jboss-enterprise-maven-repository</id>
+            <name>JBoss Enterprise Maven Repository</name>
+            <url>https://maven.repository.redhat.com/ga/</url>
+        </repository>
+    </repositories>
+	
     <dependencyManagement>
         <dependencies>
             <!-- JBoss distributes a complete set of Jakarta EE 8 APIs including

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -37,19 +37,19 @@
         <version.wildfly.maven.plugin>2.0.2.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>21.0.0.Beta1-SNAPSHOT</version.jboss.bom>
+        <version.jboss.bom>21.0.0.Final</version.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>2.22.2</version.surefire.plugin>
         <version.failsafe.plugin>2.22.2</version.failsafe.plugin>
-        <version.war.plugin>3.2.3</version.war.plugin>
+        <version.war.plugin>3.3.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
-    
+
     <dependencyManagement>
         <dependencies>
             <!-- JBoss distributes a complete set of Jakarta EE 8 APIs including


### PR DESCRIPTION
Beware, don't do a release of this archetype before this question is resolved: a project created from this archetype will not be able to resolve dependeny "org.picketbox:picketbox:jar:5.0.3.Final-redhat-00006" 
This should have been fixed by https://issues.redhat.com/browse/WFLY-13914, but it does not work for me.