### PR TITLE
[WFLY-14821] Upgrade WildFly Maven archetypes ear/webapp to Java 11

### DIFF
--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
@@ -54,8 +54,7 @@
         <version.war.plugin>3.3.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+	<maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <!-- the JBoss community and Red Hat GA Maven repositories -->

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -46,8 +46,7 @@
         <version.war.plugin>3.3.1</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+	<maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <!-- the JBoss community and Red Hat GA Maven repositories -->


### PR DESCRIPTION
Upgrade WildFly Maven archetypes for jakartaee-ear and jakartaee-webapp to Java 11

Fixes https://issues.redhat.com/browse/WFLY-14821