### PR TITLE
[WFLY-15051] Don't duplicate the package name tree in the dir where L…

### DIFF
--- a/wildfly-subsystem-archetype/archetype-metadata.xml
+++ b/wildfly-subsystem-archetype/archetype-metadata.xml
@@ -25,7 +25,7 @@
                 <include>schema/*.xsd</include>
             </includes>
         </fileSet>
-        <fileSet filtered="true" encoding="UTF-8" packaged="true">
+        <fileSet filtered="true" encoding="UTF-8" packaged="false">
             <directory>src/main/resources</directory>
             <includes>
                 <include>**/*.properties</include>


### PR DESCRIPTION
…ocalDescriptions.properties is placed

https://issues.redhat.com/browse/WFLY-15051

https://groups.google.com/g/wildfly/c/TxqN0OAH08I/m/VExXRsAyAQAJ

Caveat: I'm a total noob when it comes to this and don't really know what I'm doing here. But if I run ./create-archetype.sh install from wildfly-subsystem-archetype and then use the snapshot following the pattern shown in https://docs.wildfly.org/24/Extending_WildFly.html#create-the-skeleton-project, I end up with a project that builds, including running the subsystem tests.