### PR TITLE
[WFLY-15844] Upgrade archetypes to WildFly 26

### DIFF
--- a/wildfly-jakartaee-ear-archetype/README.adoc
+++ b/wildfly-jakartaee-ear-archetype/README.adoc
@@ -52,9 +52,9 @@ $ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sample-jakartaee-
 After having built the archetype, check whether both profiles "arq-remote" and "arq-managed" work. This is done by using scripts found in the directory "testing".
 
 * Profile "arq-managed": set variable JBOSS_HOME, then execute "runtest_managed.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
-* Profile "arq-renote": start WildFly server, then execute "runtest_remote.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
+* Profile "arq-remote": start WildFly server, then execute "runtest_remote.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
 
-Both files create a project from the archetype (in "testing/arq-managed" or "testing/arq-remote"), copy an Arquillian unit test class and and EJB in this project, then build and deploy it to WildFly and execute
+Both files create a project from the archetype (in "testing/arq-managed" or "testing/arq-remote"), copy an Arquillian unit test class and an EJB in this project, then build and deploy it to WildFly and execute
 the test using the Arquillian profile "arq-managed" or "arq-remote").
 
 After the test is executed, check the server log for error outputs. In case of success, the outputs "Test is invoked..." and "doTest is invoked..." will be printed in the server console.

--- a/wildfly-jakartaee-ear-archetype/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>38</version>
+        <version>39</version>
         <relativePath />
     </parent>
 	

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
@@ -40,10 +40,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <version.wildfly.maven.plugin>2.0.2.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>2.1.0.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>25.0.1.Final</version.jboss.bom>
+        <version.jboss.bom>26.0.0.Final</version.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/wildfly-jakartaee-webapp-archetype/README.adoc
+++ b/wildfly-jakartaee-webapp-archetype/README.adoc
@@ -50,9 +50,9 @@ $ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sampleproject -Dv
 After having built the archetype, check whether both profiles "arq-remote" and "arq-managed" work. This is done by using scripts found in the directory "testing".
 
 * Profile "arq-managed": set variable JBOSS_HOME, then execute "runtest_managed.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
-* Profile "arq-renote": start WildFly server, then execute "runtest_remote.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
+* Profile "arq-remote": start WildFly server, then execute "runtest_remote.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
 
-Both files create a project from the archetype (in "testing/arq-managed" or "testing/arq-remote"), copy an Arquillian unit test class and and EJB in this project, then build and deploy it to WildFly and execute
+Both files create a project from the archetype (in "testing/arq-managed" or "testing/arq-remote"), copy an Arquillian unit test class and an EJB in this project, then build and deploy it to WildFly and execute
 the test using the Arquillian profile "arq-managed" or "arq-remote").
 
 After the test is executed, check the server log for error outputs. In case of success, the outputs "Test is invoked..." and "doTest is invoked..." will be printed in the server console.

--- a/wildfly-jakartaee-webapp-archetype/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>38</version>
+        <version>39</version>
         <relativePath />
     </parent>
 	

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -34,10 +34,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <version.wildfly.maven.plugin>2.0.2.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>2.1.0.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>25.0.1.Final</version.jboss.bom>
+        <version.jboss.bom>26.0.0.Final</version.jboss.bom>
 
         <!-- other plugin versions -->
         <version.compiler.plugin>3.8.1</version.compiler.plugin>

--- a/wildfly-subsystem-archetype/Readme.adoc
+++ b/wildfly-subsystem-archetype/Readme.adoc
@@ -6,7 +6,7 @@ WildFly archetype for a subsystem project
 
 This archetype creates a subsystem project. 
 
-See https://docs.wildfly.org/25/Extending_WildFly.html
+See https://docs.wildfly.org/26/Extending_WildFly.html
 
 ==== New WildFly version
 To update this archetype to a new WildFly version:
@@ -21,6 +21,7 @@ In file "src/main/resources/archetype-resources/pom.xml":
 * check the plugin versions and update if necessary:
 ** maven-compiler-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/
 ** maven-surefire-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/
+** maven-antrun-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-antrun-plugin/
 
 In file "src/main/resources/archetype-resources/Readme.txt", update the version in the link to the WildFly documentation.
 

--- a/wildfly-subsystem-archetype/pom.xml
+++ b/wildfly-subsystem-archetype/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>38</version>
+        <version>39</version>
         <relativePath />
     </parent>
 	

--- a/wildfly-subsystem-archetype/src/main/resources/archetype-resources/README.txt
+++ b/wildfly-subsystem-archetype/src/main/resources/archetype-resources/README.txt
@@ -1,6 +1,6 @@
 This project was created from the archetype "wildfly-subsystem-archetype".
 
-Documentation on Subsystems can be found here: https://docs.wildfly.org/25/Extending_WildFly.html
+Documentation on Subsystems can be found here: https://docs.wildfly.org/26/Extending_WildFly.html
 
 To deploy it:
 
@@ -20,10 +20,10 @@ Register the extension in "standalone.xml" and add the subsystem configuration:
     </profile>
 
 Step 2:
-After having built this project with a call to "mvn install", the directory "target/module" will contain a subdirectoy structure
-corresponding to the module name "$module" - each "." is replaced with a path separator.
+After having built this project with a call to "mvn install", the directory "target/module" will contain a subdirectory structure
+corresponding to the module name "$module" (each "." is replaced with a path separator).
 This subdirectory contains two files "${artifactId}.jar" and "module.xml".
-Copy the subdirectory of "target/module" to "%WILDFLY_HOME%/modules/system/layers/base/.../main".
+Copy the subdirectory of "target/module" to "%WILDFLY_HOME%/modules/system/layers/base/".
 
 
 Now start the WildFly server.

--- a/wildfly-subsystem-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-subsystem-archetype/src/main/resources/archetype-resources/pom.xml
@@ -14,7 +14,7 @@
 
 
     <properties>
-		<version.wildfly.core>17.0.1.Final</version.wildfly.core>
+		<version.wildfly.core>18.0.0.Final</version.wildfly.core>
 		<version.junit>4.13.1</version.junit>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <module.name>${module}</module.name>
@@ -23,6 +23,7 @@
         <!-- other plugin versions -->
         <version.compiler.plugin>3.8.1</version.compiler.plugin>
         <version.surefire.plugin>2.22.2</version.surefire.plugin>
+		<version.antrun.plugin>3.0.0</version.antrun.plugin>
     </properties>
 
 
@@ -35,8 +36,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.compiler.plugin}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -64,7 +65,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <inherited>false</inherited>
-				<version>3.0.0</version>
+				<version>${version.antrun.plugin}</version>
                 <executions>
                     <execution>
                         <id>build-dist</id>


### PR DESCRIPTION
[https://issues.redhat.com/browse/WFLY-15844](https://issues.redhat.com/browse/WFLY-15844)

No relevent changes were necessary, mostly typo fixes in the docs. Subsystem archetype now uses Java 11.