### PR TITLE
[WFLY-16248] Update to WildFly 26.1, automated test script for subsys…

### DIFF
--- a/wildfly-jakartaee-ear-archetype/README.adoc
+++ b/wildfly-jakartaee-ear-archetype/README.adoc
@@ -44,7 +44,7 @@ It will be installed to your local maven repository at "%USERHOME%/.m2/repositor
 ==== Create project from archetype
 To create a new project from this archetype, use this maven command (replace dummy values for "groupId", "artifactId" and "version" with correct values):
 ----
-$ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sample-jakartaee-ear-archetype -Dversion=1.0-SNAPSHOT -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-ear-archetype -DarchetypeVersion=27.0.0.Final-SNAPSHOT
+$ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sample-jakartaee-ear-archetype -Dversion=1.0-SNAPSHOT -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-ear-archetype -DarchetypeVersion=26.1.0.Final-SNAPSHOT
 ----
 
 [[testing]]

--- a/wildfly-jakartaee-ear-archetype/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.wildfly.archetype</groupId>
     <artifactId>wildfly-jakartaee-ear-archetype</artifactId>
-    <version>27.0.0.Final-SNAPSHOT</version>
+    <version>26.1.0.Final-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
 
     <name>WildFly Archetypes: Jakarta EE EAR Webapp</name>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/__rootArtifactId__-web/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/__rootArtifactId__-web/pom.xml
@@ -88,6 +88,12 @@
             <artifactId>jboss-ejb-api_3.2_spec</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- Required for e.g. "javax.annotation.PostConstruct" -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
 		 
         <!-- Test scope dependencies -->
         <dependency>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/__rootArtifactId__-web/src/main/java/Jsf23Activator.java
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/__rootArtifactId__-web/src/main/java/Jsf23Activator.java
@@ -4,7 +4,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.faces.annotation.FacesConfig;
 
 /**This bean is required to activate JSF 2.3.
- * See https://github.com/eclipse-ee4j/mojarra#user-content-activating-cdi-in-jakarta-faces-30
+ * See https://github.com/eclipse-ee4j/mojarra/blob/2.3/README.md#user-content-activating-cdi-in-jakarta-faces-23
  * 
  * Remove this class if you don't need JSF.
  */

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
@@ -40,13 +40,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <version.wildfly.maven.plugin>2.1.0.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>3.0.0.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>26.0.0.Final</version.jboss.bom>
+        <version.jboss.bom>26.1.0.Final</version.jboss.bom>
 
         <!-- other plugin versions -->
-        <version.compiler.plugin>3.8.1</version.compiler.plugin>
+        <version.compiler.plugin>3.9.0</version.compiler.plugin>
         <version.ear.plugin>3.2.0</version.ear.plugin>
         <version.ejb.plugin>3.1.0</version.ejb.plugin>
         <version.surefire.plugin>2.22.2</version.surefire.plugin>

--- a/wildfly-jakartaee-webapp-archetype/README.adoc
+++ b/wildfly-jakartaee-webapp-archetype/README.adoc
@@ -42,7 +42,7 @@ It will be installed to your local maven repository at "%USERHOME%/.m2/repositor
 ==== Create project from archetype
 To create a new project from this archetype, use this maven command (replace dummy values for "groupId", "artifactId" and "version" with correct values):
 ----
-$ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sampleproject -Dversion=1.0-SNAPSHOT -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-webapp-archetype -DarchetypeVersion=27.0.0.Final-SNAPSHOT
+$ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sampleproject -Dversion=1.0-SNAPSHOT -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-webapp-archetype -DarchetypeVersion=26.1.0.Final-SNAPSHOT
 ----
 
 [[testing]]

--- a/wildfly-jakartaee-webapp-archetype/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.wildfly.archetype</groupId>
     <artifactId>wildfly-jakartaee-webapp-archetype</artifactId>
-    <version>27.0.0.Final-SNAPSHOT</version>
+    <version>26.1.0.Final-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
 
     <name>WildFly Archetypes: Jakarta EE Webapp</name>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -34,13 +34,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JBoss dependency versions -->
-        <version.wildfly.maven.plugin>2.1.0.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>3.0.0.Final</version.wildfly.maven.plugin>
 
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
-        <version.jboss.bom>26.0.0.Final</version.jboss.bom>
+        <version.jboss.bom>26.1.0.Final</version.jboss.bom>
 
         <!-- other plugin versions -->
-        <version.compiler.plugin>3.8.1</version.compiler.plugin>
+        <version.compiler.plugin>3.9.0</version.compiler.plugin>
         <version.surefire.plugin>2.22.2</version.surefire.plugin>
         <version.failsafe.plugin>2.22.2</version.failsafe.plugin>
         <version.war.plugin>3.3.2</version.war.plugin>
@@ -150,7 +150,13 @@
             <artifactId>jboss-ejb-api_3.2_spec</artifactId>
             <scope>provided</scope>
         </dependency>
-		 
+        <!-- Required for e.g. "javax.annotation.PostConstruct" -->
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.3_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+ 
         <!-- Test scope dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/java/Jsf23Activator.java
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/java/Jsf23Activator.java
@@ -4,7 +4,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.faces.annotation.FacesConfig;
 
 /**This bean is required to activate JSF 2.3.
- * See https://github.com/eclipse-ee4j/mojarra#user-content-activating-cdi-in-jakarta-faces-30
+ * See https://github.com/eclipse-ee4j/mojarra/blob/2.3/README.md#user-content-activating-cdi-in-jakarta-faces-23
  * 
  * Remove this class if you don't need JSF.
  */

--- a/wildfly-subsystem-archetype/Readme.adoc
+++ b/wildfly-subsystem-archetype/Readme.adoc
@@ -38,9 +38,28 @@ It will be installed to your local maven repository at "%USERHOME%/.m2/repositor
 ==== Create project from archetype
 To create a new project from this archetype, use this maven command (replace dummy values for "groupId", "artifactId", "version", "module" and "package" with correct values):
 ----
-$ mvn archetype:generate -DgroupId=com.acme -DartifactId=example-subsystem -Dversion=1.0-SNAPSHOT -Dmodule=org.test.subsystem -Dpackage=com.acme.example -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-subsystem -DarchetypeVersion=27.0.0.Final-SNAPSHOT
+$ mvn archetype:generate -DgroupId=com.acme -DartifactId=example-subsystem -Dversion=1.0-SNAPSHOT -Dmodule=org.test.subsystem -Dpackage=com.acme.example -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-subsystem -DarchetypeVersion=26.1.0.Final-SNAPSHOT
 ----
 
 [[testing]]
 ==== Test the archetype
+After having built the archetype, check whether the subsystem can be loaded in WildFly. This is done by using scripts "runtest.bat" or "runtest.sh" found in the directory "testing". 
+The scripts require current archetype version as argument.
+
+The script
+
+* creates a project from the subsystem archetype
+* adds some debugging code and builds the test project
+* copies the resulting subsystem to "%JBOSS_HOME%/modules/system/layers/base"
+* starts a local WildFly server
+* registers the subsystem using a CLI script
+* waits for the user to check that the debugging output of the subsystem was printed
+* finally unregisters the subsystem and stops WildFly
+
+Prerequisites
+
+* the environment variable JBOSS_HOME must point to the WildFly server corresponding to the archetyp version.
+* Windows: the git tool "patch.exe" must be found in the path
+* Linux: "GNU patch" must be installed
+
 See the steps described in "src/main/resources/archetype-resources/Readme.txt"

--- a/wildfly-subsystem-archetype/pom.xml
+++ b/wildfly-subsystem-archetype/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>org.wildfly.archetype</groupId>
     <artifactId>wildfly-subsystem</artifactId>
-    <version>27.0.0.Final-SNAPSHOT</version>
+    <version>26.1.0.Final-SNAPSHOT</version>
     <packaging>maven-archetype</packaging>
 
     <name>WildFly Archetypes: Subsystem Archetype</name>

--- a/wildfly-subsystem-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-subsystem-archetype/src/main/resources/archetype-resources/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
-    <version>27.0.0.Final-SNAPSHOT</version>
+    <version>${version}</version>
     <packaging>jar</packaging>
 
     <name>${name}</name>
@@ -14,14 +14,14 @@
 
 
     <properties>
-		<version.wildfly.core>18.0.0.Final</version.wildfly.core>
+		<version.wildfly.core>18.1.0.Final</version.wildfly.core>
 		<version.junit>4.13.1</version.junit>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <module.name>${module}</module.name>
 		
 		
         <!-- other plugin versions -->
-        <version.compiler.plugin>3.8.1</version.compiler.plugin>
+        <version.compiler.plugin>3.9.0</version.compiler.plugin>
         <version.surefire.plugin>2.22.2</version.surefire.plugin>
 		<version.antrun.plugin>3.0.0</version.antrun.plugin>
     </properties>

--- a/wildfly-subsystem-archetype/testing/.gitignore
+++ b/wildfly-subsystem-archetype/testing/.gitignore
@@ -1,0 +1,1 @@
+/example-subsystem

--- a/wildfly-subsystem-archetype/testing/configure.cli
+++ b/wildfly-subsystem-archetype/testing/configure.cli
@@ -1,0 +1,17 @@
+# Batch script to enable the elytron JAAS integration for the quickstart application in the JBoss EAP server
+
+connect
+
+# Start batching commands
+batch
+
+/extension=org.test.subsystem:add
+/subsystem=mysubsystem:add
+
+# Run the batch commands
+run-batch
+
+# Reload the server configuration
+reload
+
+

--- a/wildfly-subsystem-archetype/testing/debugging_output.patch
+++ b/wildfly-subsystem-archetype/testing/debugging_output.patch
@@ -1,0 +1,14 @@
+diff -rBNu example-subsystem.orig/src/main/java/com/acme/example/SubsystemExtension.java example-subsystem/src/main/java/com/acme/example/SubsystemExtension.java
+--- example-subsystem.orig/src/main/java/com/acme/example/SubsystemExtension.java
++++ example-subsystem/src/main/java/com/acme/example/SubsystemExtension.java
+@@ -68,6 +68,10 @@ public class SubsystemExtension implements Extension {
+         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
+
+         subsystem.registerXMLElementWriter(parser);
++
++        System.err.println("===========================================================");
++        System.err.println("mysubsystem was successfully initialized");
++        System.err.println("===========================================================");
+     }
+
+     /**

--- a/wildfly-subsystem-archetype/testing/restore-configuration-and-stop.cli
+++ b/wildfly-subsystem-archetype/testing/restore-configuration-and-stop.cli
@@ -1,0 +1,20 @@
+# Batch script to restore the JBEAP configuration that was modified to run the quickstart
+
+connect
+
+# Start batching commands
+batch
+
+/subsystem=mysubsystem:remove
+/extension=org.test.subsystem:remove
+
+# Run the batch commands
+run-batch
+
+extension-commands --errors
+
+# Reload the server configuration
+reload
+
+# Stop the server
+shutdown 

--- a/wildfly-subsystem-archetype/testing/runtest.bat
+++ b/wildfly-subsystem-archetype/testing/runtest.bat
@@ -1,0 +1,96 @@
+@REM This batch file:
+@REM 1) Creates a project from the subsystem archetype
+@REM 2) adds some debugging code and builds the test project
+@REM 3) copies the resulting subsystem to "%JBOSS_HOME%\modules\system\layers\base"
+@REM 4) starts a local WildFly server
+@REM 5) registers the subsystem using a CLI script
+@REM 6) waits for the user to check that the debugging output of the subsystem was printed
+@REM 7) finally unregisters the subsystem and stops WildFly
+@REM Prerequesites: 
+@REM -the environment variable JBOSS_HOME must point to the WildFly server corresponding to the archetyp version.
+@REM -the git tool "patch.exe" must be found in the path
+@REM The current archetype version must be the first argument to the batch file call. 
+
+@echo off
+
+@REM check that JBOSS_HOME is set:
+@if "%JBOSS_HOME%" == "" (
+  echo Environment variable JBOSS_HOME is not set
+  goto :exit
+)
+
+@REM Check for "patch.exe" on path. The switch "/q" returns an exit code instead of printing the found files.
+where.exe patch.exe /Q
+if ERRORLEVEL 1 (
+    @echo The file patch.exe could not be found. It is part of the Git client in the subdir "usr\bin". Ensure this directory is placed in your PATH.
+    goto :exit
+)
+
+@REM We need the version of the archetype to create the test project from:
+@if "%1" == "" (
+  echo Archetype version must be first argument to the call to the batch file.
+  set /p archetypeVersion=Please enter archetype version: 
+) else (
+  set archetypeVersion=%1
+)
+
+if exist example-subsystem (
+  @ECHO delete old test project
+  rmdir /S /Q example-subsystem
+)
+@REM if directory still exists then fail
+if exist example-subsystem (
+  @echo [ERROR] directory 'example-subsystem' could not be deleted
+  goto :exit
+)
+
+@ECHO generate project from archetype.
+call mvn archetype:generate -DgroupId=com.acme -DartifactId=example-subsystem -Dversion=1.0-SNAPSHOT -Dmodule=org.test.subsystem -Dpackage=com.acme.example -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-subsystem -DarchetypeVersion=%archetypeVersion% -DinteractiveMode=false
+if %ERRORLEVEL% NEQ 0 (
+  @echo [ERROR] Maven project creation failed. Errorlevel: %ERRORLEVEL%
+  goto :exit
+)
+
+
+@ECHO Applying patch (using the git patch utility)...
+patch.exe --verbose -p0 < debugging_output.patch
+@ECHO Patch was applied.
+
+cd example-subsystem
+
+@ECHO compiling project...
+call mvn install
+
+@REM go back one directory - otherwise all CMD windows that are opened in the next steps block further runs of this script as the "example-subsystem" directory cannot be deleted if a CMD window is open.
+cd..
+
+@ECHO Copying module to WildFly...
+@REM "/Y" does not ask for overwrite confirmations (if previous script runs did not finish)
+xcopy /E /Y example-subsystem\target\module\org %JBOSS_HOME%\modules\system\layers\base\org\
+
+@ECHO WildFly server is starting...
+start  %JBOSS_HOME%\bin\standalone.bat
+@ECHO Press enter when WildFly was started to continue the test
+@pause
+
+@ECHO Configuring subsystem...
+@ECHO This might cause errors if a previous test run did not cleanup and e.g. the subsystem already exists.
+CALL %JBOSS_HOME%\bin\jboss-cli.bat --file=configure.cli
+
+@ECHO Subsystem was registered - check WildFly console for error messages.
+@ECHO If all went well, there will be an output "mysubsystem was successfully initialized".
+@REM print blank line (sounds strange, but works)
+@ECHO(
+@ECHO After you checked this, press enter to unregister the subsystem and do cleanup.
+@PAUSE
+
+@ECHO Unregistering subsystem and stopping WildFly...
+CALL %JBOSS_HOME%\bin\jboss-cli.bat --file=restore-configuration-and-stop.cli
+
+@REM Delete the subsystem files
+@REM "/s" deletes tree, "/q" does not prompt for confirmation
+rmdir /s /q %JBOSS_HOME%\modules\system\layers\base\org\test
+
+@ECHO You are done. Now close the CMD window (WildFly console).
+
+:exit

--- a/wildfly-subsystem-archetype/testing/runtest.sh
+++ b/wildfly-subsystem-archetype/testing/runtest.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# This script:
+# 1) Creates a project from the subsystem archetype
+# 2) adds some debugging code and builds the test project
+# 3) copies the resulting subsystem to "%JBOSS_HOME%\modules\system\layers\base"
+# 4) starts a local WildFly server
+# 5) registers the subsystem using a CLI script
+# 6) waits for the user to check that the debugging output of the subsystem was printed
+# 7) finally unregisters the subsystem and stops WildFly
+# Prerequesites: 
+# -the environment variable JBOSS_HOME must point to the WildFly server corresponding to the archetyp version.
+# -the git tool "patch.exe" must be found in the path
+# The current archetype version must be the first argument to the script call. 
+
+
+# check that JBOSS_HOME is set:
+if [ -z $JBOSS_HOME ]
+  then
+  echo "Environment variable JBOSS_HOME is not set"
+  exit 1
+fi
+
+# Check for "patch" command.
+if ! command -v patch &> /dev/null
+  then
+  echo "The command patch could not be found. Please install GNU patch"
+  exit 1
+fi
+
+# We need the version of the archetype to create the test project from:
+if [ -z "$1" ]
+  then
+    echo "Archetype version must be first argument to the call to the script."
+    read -p "Please enter archetype version: " archetypeVersion
+  else
+    archetypeVersion=$1
+fi
+
+
+if [ -d "example-subsystem" ]; then
+  echo "delete old test project"
+  rm -rf example-subsystem
+fi
+
+#if directory still exists then fail
+if [ -d "example-subsystem" ]; then
+  echo "[ERROR] directory 'example-subsystem' could not be deleted"
+  exit 1
+fi
+
+echo "generate project from archetype."
+mvn archetype:generate -DgroupId=com.acme -DartifactId=example-subsystem -Dversion=1.0-SNAPSHOT -Dmodule=org.test.subsystem -Dpackage=com.acme.example -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-subsystem -DarchetypeVersion=$archetypeVersion -DinteractiveMode=false
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "[ERROR] Maven project creation failed. Errorcode: $retVal"
+  exit 1
+fi
+
+
+echo "Applying patch (using the git patch utility)..."
+patch --verbose -p0 < debugging_output.patch
+echo "Patch was applied."
+
+cd example-subsystem
+
+echo "compiling project..."
+mvn install
+
+# go back one directory (just to keep the script similar to the bat file, see there).
+cd ..
+
+
+echo "Copying module to WildFly..."
+cp -r example-subsystem/target/module/org $JBOSS_HOME/modules/system/layers/base
+
+
+echo "WildFly server is starting..."
+konsole -e $JBOSS_HOME/bin/standalone.sh &
+
+read -n1 -r -p "Press enter when WildFly was started to continue the test" key
+
+echo "Configuring subsystem..."
+echo "This might cause errors if a previous test run did not cleanup and e.g. the subsystem already exists."
+$JBOSS_HOME/bin/jboss-cli.sh --file=configure.cli
+
+
+echo "Subsystem was registered - check WildFly console for error messages."
+echo "If all went well, there will be an output 'mysubsystem was successfully initialized'".
+echo
+read -n1 -r -p "After you checked this, press enter to unregister the subsystem and do cleanup." key
+
+
+echo "Unregistering subsystem and stopping WildFly..."
+$JBOSS_HOME/bin/jboss-cli.sh --file=restore-configuration-and-stop.cli
+
+# Delete the subsystem files
+rm -r $JBOSS_HOME/modules/system/layers/base/org/test
+
+
+echo "You are done."


### PR DESCRIPTION
[https://issues.redhat.com/browse/WFLY-16248](https://issues.redhat.com/browse/WFLY-16248)

Updates the EAR, WAR and subsystem archetypes  to WildFly 26.1.
Adds automated test for the subsystem archetype, similar to the tests for the other archetypes.

Bugfixing/minor changes:
-the subsystem archetype creates a project with a fixed version instead of using the version argument of "mvn generate".
-the "JsfActivator" class has a link pointing to https://github.com/eclipse-ee4j/mojarra#user-content-activating-cdi-in-jakarta-faces-30 that is wrong now (points to the JSF 4 page), it has to be https://github.com/eclipse-ee4j/mojarra/blob/2.3/README.md#user-content-activating-cdi-in-jakarta-faces-23
-add dependency "org.jboss.spec.javax.annotation" to the pom.xml of the web projects, as it contains e.g. the annotation "javax.annotation.PostConstruct" that might be needed. The dependency is already contained in the ejb project of the EAR archetype.