### PR TITLE
[WFLY-17887] The minimum support Java version for WildFly is still Java 11.

### DIFF
--- a/wildfly-jakartaee-ear-archetype/README.adoc
+++ b/wildfly-jakartaee-ear-archetype/README.adoc
@@ -33,7 +33,7 @@ Also test whether the Arquillian unit test "SampleIT" still works, see below.
 
 [[build]]
 ==== Build
-To build the archetype, you need at least Java 17. Run this command:
+To build the archetype, you need at least Java 11. Run this command:
 [source,options="nowrap"]
 ----
 $ mvn clean install

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
@@ -54,7 +54,7 @@
         <version.war.plugin>3.3.2</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <!-- the JBoss community and Red Hat GA Maven repositories -->

--- a/wildfly-jakartaee-webapp-archetype/README.adoc
+++ b/wildfly-jakartaee-webapp-archetype/README.adoc
@@ -31,7 +31,7 @@ Also test whether the Arquillian unit test "SampleIT" still works, see below.
 
 [[build]]
 ==== Build
-To build the archetype, you need at least Java 17. Run this command:
+To build the archetype, you need at least Java 11. Run this command:
 [source,options="nowrap"]
 ----
 $ mvn clean install

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -46,7 +46,7 @@
         <version.war.plugin>3.3.2</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
     <!-- the JBoss community and Red Hat GA Maven repositories -->

--- a/wildfly-subsystem-archetype/Readme.adoc
+++ b/wildfly-subsystem-archetype/Readme.adoc
@@ -27,7 +27,7 @@ In file "src/main/resources/archetype-resources/Readme.txt", update the version 
 
 [[build]]
 ==== Build
-To build the archetype, you need at least Java 17. Run this command:
+To build the archetype, you need at least Java 11. Run this command:
 [source,options="nowrap"]
 ----
 $ mvn clean install

--- a/wildfly-subsystem-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-subsystem-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,7 +26,7 @@
 		<version.antrun.plugin>3.1.0</version.antrun.plugin>
 		
         <!-- maven-compiler-plugin -->
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>11</maven.compiler.release>
     </properties>
 
 
@@ -39,6 +39,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.compiler.plugin}</version>
                 <configuration>
+                    <source>11</source>
+                    <target>11</target>
                     <!-- put your configurations here -->
                 </configuration>
             </plugin>


### PR DESCRIPTION
Archetypes would typically be used by new users, at the moment even though they have a valid JDK installed forcing the use of Java 17 triggers a risk of an early error they have to correct before they can proceed.

We should be looking to go the other direction and minimise the steps it takes for someone to get a project up and running.

https://issues.redhat.com/browse/WFLY-17887