### PR TITLE
Enable dependabot update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: maven
+    directory: "/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: maven
+    directory: "/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+  - package-ecosystem: maven
+    directory: "/wildfly-subsystem-archetype/src/main/resources/archetype-resources/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10


### PR DESCRIPTION
for the archetypes modules and the projects that they generate