### PR TITLE
Update EAR dependencies

### DIFF
--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/pom.xml
@@ -49,9 +49,8 @@
         <version.compiler.plugin>3.9.0</version.compiler.plugin>
         <version.ear.plugin>3.3.0</version.ear.plugin>
         <version.ejb.plugin>3.2.1</version.ejb.plugin>
-        <version.surefire.plugin>3.0.0</version.surefire.plugin>
-        <version.failsafe.plugin>3.0.0</version.failsafe.plugin>
-        <version.war.plugin>3.3.2</version.war.plugin>
+        <version.failsafe.plugin>3.1.2</version.failsafe.plugin>
+        <version.war.plugin>3.4.0</version.war.plugin>
 
         <!-- maven-compiler-plugin -->
         <maven.compiler.release>11</maven.compiler.release>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/pom.xml
@@ -41,7 +41,6 @@
 
         <!-- other plugin versions -->
         <version.compiler.plugin>3.9.0</version.compiler.plugin>
-        <version.surefire.plugin>3.0.0</version.surefire.plugin>
         <version.failsafe.plugin>3.1.2</version.failsafe.plugin>
         <version.war.plugin>3.4.0</version.war.plugin>
 


### PR DESCRIPTION
* Bump version.failsafe.plugin to 3.1.2
* Bump version.war.plugin to 3.4.0
* Remove version.surefire.plugin as this plugin is not used by the EAR archetype
* Idem for the webapp archetype