### PR TITLE
Switch to arquillian-protocol-servlet-jakarta

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ To update the archetypes to new versions:
 
 * update to latest "org.jboss:jboss-parent" version found at https://repo.maven.apache.org/maven2/org/jboss/jboss-parent/
 * update the version property named "version.wildfly.bom"
+* update the version property named "version.wildfly.core" to the version bundled with WildFly (found in "%WILDFLY_HOME%/modules/system/layers/base/org/jboss/as/controller/main").
 * check whether dependencies have changed.
 * check the plugin versions and update if necessary:
   * wildfly-maven-plugin: https://repo.maven.apache.org/maven2/org/wildfly/plugins/wildfly-maven-plugin/

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/pom.xml
@@ -71,7 +71,7 @@
 
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/pom.xml
@@ -113,7 +113,7 @@
       
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
             <scope>test</scope>               
         </dependency>
     </dependencies>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -175,7 +175,7 @@
       
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
             <scope>test</scope>               
         </dependency>
     </dependencies>


### PR DESCRIPTION
After switching to 30.0.0.Beta1, there is an error when creating projects from the archetypes:

`'dependencies.dependency.version' for org.jboss.arquillian.protocol:arquillian-protocol-servlet:jar is missing`

It should use the JakartaEE version: `org.jboss.arquillian.protocol:arquillian-protocol-servlet-jakarta`. There was probably some cleanup in the WildFly BOM that removed the dependency on the old artifact. Strange enough that the JavaEE version worked since WildFly 27 ;-).

The change also works when using WildFly 29.0.1.Final, so it is safe to merge this change before the switch to 30.0

I also restored one line in the "update to new WildFly version guide" in README.md, that is specific to the subsystem archetype.
