### PR TITLE
Downgrade archetype-plugin from 3.2.1 to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,13 @@
                     <artifactId>maven-war-plugin</artifactId>
                     <version>${version.war.plugin}</version>
                 </plugin>
+                <!--Workaround: downgrade maven-archetype-plugin to 3.1.2, as 3.2.1 from jboss-parent 40 prints a warning when creating a project from this archetype.
+                    For details see https://github.com/wildfly/wildfly-archetypes/issues/51 -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-archetype-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
This avoids a warning that is printed when the archetype is generated by archetype plugin version 3.2.1 (which was updated as part of the jboss-parent update to 40).

More details see #51

I created a Maven issue, maybe they give feedback that the warning is actually a problem in "archetype-metadata.xml", but I don't see anything problematic here.