### PR TITLE
Added missing groupId for maven-war-plugin

### DIFF
--- a/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -140,8 +140,7 @@
         <finalName>ROOT</finalName>
 
         <plugins>
-            <!--Configuration
-            of the maven-compiler-plugin -->
+            <!--Configuration of the maven-compiler-plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -149,9 +148,9 @@
                 <configuration></configuration>
             </plugin>
 
-            <!--Build
-            configuration for the WAR plugin: -->
+            <!--Build configuration for the WAR plugin: -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>\${version.war.plugin}</version>
                 <configuration>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/pom.xml
@@ -121,6 +121,7 @@
         <plugins>
             <!--Build configuration for the WAR plugin: -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>${version.war.plugin}</version>
                 <configuration>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -193,6 +193,7 @@
 
             <!--Build configuration for the WAR plugin: -->
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <version>\${version.war.plugin}</version>
                 <configuration>


### PR DESCRIPTION
"maven-war-plugin" had no groupId. It worked anyway, but it is cleaner to declare it.