### PR TITLE
Switched archetypes to JUnit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
         <version.wildfly.core>22.0.1.Final</version.wildfly.core>
         <version.wildfly.maven.plugin>4.2.1.Final</version.wildfly.maven.plugin>
 
+        <!--Use JUnit 5 here - the WildFly bom still brings 4.x -->
+        <version.junit5>5.10.1</version.junit5>
+        <!--Only the subsystem archetype has to stick with JUnit 4-->
+        <version.junit4>4.13.2</version.junit4>
+
         <version.compiler.plugin>3.9.0</version.compiler.plugin>
         <version.surefire.plugin>3.0.0</version.surefire.plugin>
         <version.failsafe.plugin>3.2.2</version.failsafe.plugin>

--- a/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -38,6 +38,9 @@
         <version.wildfly.maven.plugin>${version.wildfly.maven.plugin}</version.wildfly.maven.plugin>
         <version.wildfly.bom>${version.wildfly.bom}</version.wildfly.bom>
 
+        <!--Use JUnit 5 here - the WildFly bom still brings 4.x -->
+        <version.junit5>${version.junit5}</version.junit5>
+
         <!-- other plugin versions -->
         <version.compiler.plugin>${version.compiler.plugin}</version.compiler.plugin>
         <version.surefire.plugin>${version.surefire.plugin}</version.surefire.plugin>
@@ -89,6 +92,15 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <!--Define the JUnit5 bom. WildFly BOM still contains JUnit4, so we have to declare a version here -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${version.junit5}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -110,14 +122,14 @@
 
         <!-- Test scope dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/test/java/__defaultClassPrefix__ApplicationIT.java
+++ b/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/test/java/__defaultClassPrefix__ApplicationIT.java
@@ -3,7 +3,7 @@
 #set( $symbol_escape = '\' )
 package ${package};
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 
@@ -11,15 +11,15 @@ import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Response;
 import org.jboss.arquillian.container.test.api.RunAsClient;
-import org.jboss.arquillian.junit.Arquillian;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Run integration tests against the server and the deployed application.
  */
 @RunAsClient
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class ${defaultClassPrefix}ApplicationIT {
 
     @Test

--- a/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/test/java/__defaultClassPrefix__ServiceIT.java
+++ b/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/test/java/__defaultClassPrefix__ServiceIT.java
@@ -3,22 +3,22 @@
 #set( $symbol_escape = '\' )
 package ${package};
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import jakarta.inject.Inject;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Run integration tests with Arquillian to be able to test CDI beans
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class  ${defaultClassPrefix}ServiceIT {
 
     @Deployment

--- a/wildfly-jakartaee-ear-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -45,6 +45,9 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <version.wildfly.bom>${version.wildfly.bom}</version.wildfly.bom>
 
+        <!--Use JUnit 5 here - the WildFly bom still brings 4.x -->
+        <version.junit5>${version.junit5}</version.junit5>
+
         <!-- other plugin versions -->
         <version.compiler.plugin>${version.compiler.plugin}</version.compiler.plugin>
         <version.ear.plugin>${version.ear.plugin}</version.ear.plugin>
@@ -119,6 +122,15 @@
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-ee-with-tools</artifactId>
                 <version>\${version.wildfly.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!--Define the JUnit5 bom. WildFly BOM still contains JUnit4, so we have to declare a version here -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${version.junit5}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/README.txt
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/README.txt
@@ -24,7 +24,7 @@ In case you don't want to use JSF, simply delete this file and "src/main/webapp/
 ==========================
 
 Testing:
-This sample is prepared for running unit tests with the Arquillian framework.
+This sample is prepared for running JUnit5 unit tests with the Arquillian framework.
 
 The configuration can be found in "${rootArtifactId}/pom.xml":
 

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/pom.xml
@@ -39,8 +39,8 @@
 
         <!-- Test scope dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/pom.xml
@@ -97,8 +97,8 @@
 
         <!-- Test scope dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -106,8 +106,8 @@
         <!-- Arquillian allows you to test enterprise code such as EJBs and
             Transactional(JTA) JPA from JUnit/TestNG -->
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/test/java/test/SampleIT.java
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/test/java/test/SampleIT.java
@@ -3,22 +3,22 @@ package ${package}.test;
 import java.io.File;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Sample integration test: demonstrates how to create the EAR file using the ShrinkWrap API.
  *
  * Delete this file if no integration test is required.
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class SampleIT {
 
     /**

--- a/wildfly-jakartaee-ear-archetype/testing/additionalfiles/ArchetypeIT.java
+++ b/wildfly-jakartaee-ear-archetype/testing/additionalfiles/ArchetypeIT.java
@@ -1,8 +1,8 @@
 package foo.bar.multi.test;
 
-import org.jboss.arquillian.junit.Arquillian;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import jakarta.ejb.EJB;
 import foo.bar.multi.TestLocal;
@@ -10,7 +10,7 @@ import foo.bar.multi.TestLocal;
 /**
  * This integration test is used to validate the project created from the archetype.
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class ArchetypeIT extends SampleIT{
 
   @EJB

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -39,6 +39,9 @@
         <!-- Define the version of the JBoss BOMs we want to import to specify tested stacks. -->
         <version.wildfly.bom>${version.wildfly.bom}</version.wildfly.bom>
 
+        <!--Use JUnit 5 here - the WildFly bom still brings 4.x -->
+        <version.junit5>${version.junit5}</version.junit5>
+
         <!-- other plugin versions -->
         <version.compiler.plugin>${version.compiler.plugin}</version.compiler.plugin>
         <version.surefire.plugin>${version.surefire.plugin}</version.surefire.plugin>
@@ -92,6 +95,15 @@
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-ee-with-tools</artifactId>
                 <version>\${version.wildfly.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <!--Define the JUnit5 bom. WildFly BOM still contains JUnit4, so we have to declare a version here -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${version.junit5}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -159,8 +171,8 @@
 
         <!-- Test scope dependencies -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -168,8 +180,8 @@
         <!-- Arquillian allows you to test enterprise code such as EJBs and
             Transactional(JTA) JPA from JUnit/TestNG -->
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/README.txt
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/README.txt
@@ -24,7 +24,7 @@ In case you don't want to use JSF, simply delete this file and "src/main/webapp/
 ==========================
 
 Testing:
-This sample is prepared for running unit tests with the Arquillian framework.
+This sample is prepared for running JUnit5 unit tests with the Arquillian framework.
 
 The configuration can be found in "${rootArtifactId}/pom.xml":
 

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/test/java/test/SampleIT.java
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/test/java/test/SampleIT.java
@@ -3,20 +3,20 @@ package ${package}.test;
 import java.io.File;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.importer.ZipImporter;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Sample integration test: demonstrates how to create the WAR file using the ShrinkWrap API.
  *
  * Delete this file if no integration test is required.
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class SampleIT {
 
     /**

--- a/wildfly-jakartaee-webapp-archetype/testing/additionalfiles/ArchetypeIT.java
+++ b/wildfly-jakartaee-webapp-archetype/testing/additionalfiles/ArchetypeIT.java
@@ -1,8 +1,8 @@
 package foo.bar.multi.test;
 
-import org.jboss.arquillian.junit.Arquillian;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import jakarta.ejb.EJB;
 import foo.bar.multi.TestLocal;
@@ -10,7 +10,7 @@ import foo.bar.multi.TestLocal;
 /**
  * This integration test is used to validate the project created from the archetype.
  */
-@RunWith(Arquillian.class)
+@ExtendWith(ArquillianExtension.class)
 public class ArchetypeIT extends SampleIT{
 
   @EJB

--- a/wildfly-subsystem-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-subsystem-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -15,7 +15,8 @@
 
     <properties>
         <version.wildfly.core>${version.wildfly.core}</version.wildfly.core>
-        <version.junit>4.13.2</version.junit>
+        <!--Stay with JUnit 4, as "org.wildfly.core:wildfly-subsystem-test-framework" does not support JUnit 5-->
+        <version.junit>${version.junit4}</version.junit>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <module.name>\${module}</module.name>
 


### PR DESCRIPTION
I suggest to use JUnit5 in the archetypes where possible. What do you think?

WildFly BOM still brings JUnit4, so i have to define a JUnit5 version. And the sample at https://github.com/junit-team/junit5-samples/blob/r5.10.1/junit5-jupiter-starter-maven/pom.xml defines a "junit-bom" in "dependencyManagement", so I followed this sample, too. Don't know whether this is required, as some of the components are probably not usable in the arquillian environment.

The subsystem archetype has to stay with JUnit4, as "org.wildfly.core:wildfly-subsystem-test-framework" (https://github.com/wildfly/wildfly-core/tree/main/subsystem-test/framework) only supports JUnit4 and thus the subsystem tests would fail with JUnit5.
