### PR TITLE
Remove resteasy version from gettingstarted archetype, as it is provided

### DIFF
--- a/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -142,7 +142,6 @@
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.4.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
The "gettingstarted" defined a resteasy version. This does not seem to be necessary, as it is provided by WildFly. And the version 6.2.4 was not updated when switching the archetype to WildFly 30 - here it is 6.2.5

If you want to keep the version, we should use a variable defined in the root pom so that dependabot can pull updates.