### PR TITLE
Fix typo in js use strict pragma

### DIFF
--- a/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/main/webapp/index.html
+++ b/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/main/webapp/index.html
@@ -35,7 +35,7 @@
     <link rel="shortcut icon" href="favicon.ico" type="image/x-icon"/>
     <script>
         (() => {
-            "use script";
+            "use strict";
             window.addEventListener("load", () => {
                 const button = document.querySelector("button[type='submit']");
                 button.addEventListener("click", (event) => {


### PR DESCRIPTION
Was following https://www.wildfly.org/get-started/ and browsing the files in the project created by wildfly-getting-started-archetype. I noticed this typo in the javascript inside the index.html file. I assume it was meant to invoke javascript's strict mode.