### PR TITLE
Upgrade to WildFly 33.0.0.Final BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         actually use these dependencies.
     -->
     <properties>
-        <version.wildfly.bom>32.0.1.Final</version.wildfly.bom>
+        <version.wildfly.bom>33.0.0.Final</version.wildfly.bom>
         <version.wildfly.core>25.0.0.Final</version.wildfly.core>
         <version.wildfly.maven.plugin>5.0.0.Final</version.wildfly.maven.plugin>
 

--- a/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -162,6 +162,11 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
+            <!-- temporary overriding as the 1.8.1.Final version pulled by
+                 WildFly BOM does not work with JUnit 5
+                 https://github.com/arquillian/arquillian-core/issues/576
+            -->
+            <version>1.9.1.Final</version>
             <scope>test</scope>
         </dependency>
 

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/pom.xml
@@ -108,6 +108,11 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
+            <!-- temporary overriding as the 1.8.1.Final version pulled by
+                 WildFly BOM does not work with JUnit 5
+                 https://github.com/arquillian/arquillian-core/issues/576
+            -->
+            <version>1.9.1.Final</version>
             <scope>test</scope>
         </dependency>
 

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -214,6 +214,11 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
+            <!-- temporary overriding as the 1.8.1.Final version pulled by
+                 WildFly BOM does not work with JUnit 5
+                 https://github.com/arquillian/arquillian-core/issues/576
+            -->
+            <version>1.9.1.Final</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
In the getting-started archetype, override arquillian-junit5-container version to 1.9.1.Final as the version coming from WildFly BOM (1.8.1.Final) is not working.