### PR TITLE
Rename JSF to Jakarta Faces, remove outdated comment in beans.xml, up…

### DIFF
--- a/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
+++ b/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
@@ -9,7 +9,7 @@
       https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
    bean-discovery-mode="annotated">
 
-   <!-- This descriptor configures Context and Dependeny Injection.
-        Actually, CDI 1.1 does not require this file. But the archetype contains it anyway to avoid deloyment errors for blank projects (WFLY-13306)   -->
+   <!-- This descriptor configures Context and Dependeny Injection (CDI).
+        This file is optional.  -->
 
 </beans>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/README.txt
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/README.txt
@@ -18,9 +18,9 @@ in "persistence.xml".
 If you don't use entity beans, you can delete "persistence.xml".
 ==========================
 
-JSF:
-The web application is prepared for JSF 4.0 by bundling an empty "faces-config.xml" in "src/main/webapp/WEB-INF".
-In case you don't want to use JSF, simply delete this file and "src/main/webapp/beans.xml".
+Jakarta Faces:
+The web application is prepared for Jakarta Faces 4.0 by bundling an empty "faces-config.xml" in "src/main/webapp/WEB-INF".
+In case you don't want to use Jakarta Faces, simply delete this file and "src/main/webapp/beans.xml".
 ==========================
 
 Testing:

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/src/main/resources/META-INF/persistence.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/src/main/resources/META-INF/persistence.xml
@@ -30,9 +30,9 @@
              Hibernate property instead:
              <property name="hibernate.hbm2ddl.auto" value="create-drop" />
          -->
-         <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
-         <property name="javax.persistence.schema-generation.create-source" value="metadata"/>
-         <property name="javax.persistence.schema-generation.drop-source" value="metadata"/>
+         <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>
+         <property name="jakarta.persistence.schema-generation.create-source" value="metadata"/>
+         <property name="jakarta.persistence.schema-generation.drop-source" value="metadata"/>
 
          <!-- Properties for Hibernate -->
          <property name="hibernate.show_sql" value="false" />

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/main/webapp/WEB-INF/beans.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/main/webapp/WEB-INF/beans.xml
@@ -6,7 +6,7 @@
       https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
    bean-discovery-mode="annotated">
 
-   <!-- This descriptor configures Context and Dependeny Injection.
-        Actually, CDI 1.1 does not require this file. But the archetype contains it anyway to avoid deloyment errors for blank projects (WFLY-13306)   -->
+   <!-- This descriptor configures Context and Dependeny Injection (CDI).
+        This file is optional. -->
 
 </beans>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/main/webapp/WEB-INF/faces-config.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/main/webapp/WEB-INF/faces-config.xml
@@ -6,7 +6,7 @@
         https://jakarta.ee/xml/ns/jakartaee
         https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd">
 
-   <!-- This descriptor activates the JSF Servlet -->
+   <!-- This descriptor activates the Jakarta Faces Servlet -->
 
    <!-- Write your navigation rules here. You are encouraged to use CDI for
       creating @Named managed beans. -->

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/README.txt
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/README.txt
@@ -18,9 +18,9 @@ in "persistence.xml".
 If you don't use entity beans, you can delete "persistence.xml".
 ==========================
 
-JSF:
-The web application is prepared for JSF 4.0 by bundling an empty "faces-config.xml" in "src/main/webapp/WEB-INF".
-In case you don't want to use JSF, simply delete this file and "src/main/webapp/beans.xml".
+Jakarta Faces:
+The web application is prepared for Jakarta Faces 4.0 by bundling an empty "faces-config.xml" in "src/main/webapp/WEB-INF".
+In case you don't want to use Jakarta Faces, simply delete this file and "src/main/webapp/beans.xml".
 ==========================
 
 Testing:

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/persistence.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/persistence.xml
@@ -30,9 +30,9 @@
              Hibernate property instead:
              <property name="hibernate.hbm2ddl.auto" value="create-drop" />
          -->
-         <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
-         <property name="javax.persistence.schema-generation.create-source" value="metadata"/>
-         <property name="javax.persistence.schema-generation.drop-source" value="metadata"/>
+         <property name="jakarta.persistence.schema-generation.database.action" value="drop-and-create"/>
+         <property name="jakarta.persistence.schema-generation.create-source" value="metadata"/>
+         <property name="jakarta.persistence.schema-generation.drop-source" value="metadata"/>
 
          <!-- Properties for Hibernate -->
          <property name="hibernate.show_sql" value="false" />

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
@@ -6,7 +6,7 @@
       https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
    bean-discovery-mode="annotated">
 
-   <!-- This descriptor configures Context and Dependeny Injection.
-        Actually, CDI 1.1 does not require this file. But the archetype contains it anyway to avoid deloyment errors for blank projects (WFLY-13306)   -->
+   <!-- This descriptor configures Context and Dependeny Injection (CDI).
+        This file is optional. -->
 
 </beans>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/faces-config.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/faces-config.xml
@@ -6,7 +6,7 @@
         https://jakarta.ee/xml/ns/jakartaee
         https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd">
 
-   <!-- This descriptor activates the JSF Servlet -->
+   <!-- This descriptor activates the Jakarta Faces Servlet -->
 
    <!-- Write your navigation rules here. You are encouraged to use CDI for
       creating @Named managed beans. -->


### PR DESCRIPTION
...date properties in persistence.xml

A bit of cleanup:

1. JSF / "Java Server Faces" was renamed to "Jakarta Faces"
2. there was a comment in beans.xml pointing to https://issues.redhat.com/browse/WFLY-13306. The original error when deploying an empty project without "beans.xml" does not happen any more, so I removed the comment and stated that the file is optional. It could also be deleted, but I consider it helpful to have stubs for all relevant deployment descriptors.
3.  "persistence.xml" caused a deployment warning:
    ```
    19:23:20,269 WARN  [org.hibernate.orm.deprecation] (ServerService Thread Pool -- 94) HHH90000021: Encountered deprecated setting [javax.persistence.schema-generation.database.action], use [jakarta.persistence.schema-generation.database.action] instead
    ```
    So I renamed those properties.