### PR TITLE
Upgrade to WildFly 33.0.2.Final

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -40,8 +40,8 @@ jobs:
         echo "## Testing archetypes ${ARCHETYPE_VERSION} with WildFly ${WILDFLY_VERSION}" >> $GITHUB_STEP_SUMMARY
     - name: Download WildFly
       run: |-
-        wget -q https://github.com/wildfly/wildfly/releases/download/${WILDFLY_VERSION}/wildfly-${WILDFLY_VERSION}.zip
-        unzip -q wildfly-${WILDFLY_VERSION}.zip
+        wget -q https://repository.jboss.org/org/wildfly/wildfly-dist/$WILDFLY_VERSION/wildfly-dist-$WILDFLY_VERSION.zip
+        unzip -q wildfly-dist-${WILDFLY_VERSION}.zip
         JBOSS_HOME=$(pwd)/wildfly-${WILDFLY_VERSION}
         echo "JBOSS_HOME=$JBOSS_HOME" >> "$GITHUB_ENV"
     - name: Run Jakarta EE Webapp Archetype Tests

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         actually use these dependencies.
     -->
     <properties>
-        <version.wildfly.bom>33.0.1.Final</version.wildfly.bom>
+        <version.wildfly.bom>33.0.2.Final</version.wildfly.bom>
         <version.wildfly.core>25.0.2.Final</version.wildfly.core>
         <version.wildfly.maven.plugin>5.0.1.Final</version.wildfly.maven.plugin>
 


### PR DESCRIPTION
For testing download the WildFly zip archives from the Maven repository so that we do not have to wait for the release to be published on GitHub to test and release the archetypes