### PR TITLE
Update to WildFly 34.0.0.Beta1, GettingStarted requires commons-logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
         actually use these dependencies.
     -->
     <properties>
-        <version.wildfly.bom>33.0.2.Final</version.wildfly.bom>
-        <version.wildfly.core>25.0.2.Final</version.wildfly.core>
+        <version.wildfly.bom>34.0.0.Beta1</version.wildfly.bom>
+        <version.wildfly.core>26.0.0.Beta5</version.wildfly.core>
         <version.wildfly.maven.plugin>5.0.1.Final</version.wildfly.maven.plugin>
 
         <!--Use JUnit 5 here - the WildFly bom still brings 4.x -->

--- a/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -186,6 +186,16 @@
             <artifactId>resteasy-client</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!--See https://issues.redhat.com/browse/WFLY-19779 and https://github.com/wildfly/quickstart/pull/957/
+            httpclient needs commons-logging yet the server uses this instead,
+            to be fully compatible on apps we need to add this dependency whenever commons-logging is needed,
+            but on testing clients like this we could use commons-logging instead -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>commons-logging-jboss-logging</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Resolves #112

This is only a draft as long as Wildfly 34 is not released. I send this pull request anyway to point to this issue and get comments on the workaround - as I copied it from the quickstarts, I hope it is valid. 
