### PR TITLE
Cleanup: removed unnecessary surefire version, updated dependency comment

### DIFF
--- a/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -43,7 +43,6 @@
 
         <!-- other plugin versions -->
         <version.compiler.plugin>${version.compiler.plugin}</version.compiler.plugin>
-        <version.surefire.plugin>${version.surefire.plugin}</version.surefire.plugin>
         <version.failsafe.plugin>${version.failsafe.plugin}</version.failsafe.plugin>
         <version.war.plugin>${version.war.plugin}</version.war.plugin>
 

--- a/wildfly-jakartaee-ear-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -52,7 +52,6 @@
         <version.compiler.plugin>${version.compiler.plugin}</version.compiler.plugin>
         <version.ear.plugin>${version.ear.plugin}</version.ear.plugin>
         <version.ejb.plugin>${version.ejb.plugin}</version.ejb.plugin>
-        <version.surefire.plugin>${version.surefire.plugin}</version.surefire.plugin>
         <version.failsafe.plugin>${version.failsafe.plugin}</version.failsafe.plugin>
         <version.war.plugin>${version.war.plugin}</version.war.plugin>
 
@@ -145,11 +144,11 @@
                 <scope>compile</scope>
             </dependency>
 
-            <!-- JBoss distributes a complete set of Jakarta EE 8 APIs including
+            <!-- JBoss distributes a complete set of Jakarta EE APIs including
                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
                 a collection) of artifacts. We use this here so that we always get the correct
-                versions of artifacts. Here we use the wildfly-jakartaee-8.0-with-tools stack
-                (you can read this as the WildFly stack of the Jakarta EE 8 APIs -->
+                versions of artifacts (you can read this as the WildFly stack of the Jakarta EE APIs,
+                with some extras tools for your project, such as Arquillian for testing) -->
             <dependency>
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-ee-with-tools</artifactId>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -44,7 +44,6 @@
 
         <!-- other plugin versions -->
         <version.compiler.plugin>${version.compiler.plugin}</version.compiler.plugin>
-        <version.surefire.plugin>${version.surefire.plugin}</version.surefire.plugin>
         <version.failsafe.plugin>${version.failsafe.plugin}</version.failsafe.plugin>
         <version.war.plugin>${version.war.plugin}</version.war.plugin>
 
@@ -117,12 +116,11 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- JBoss distributes a complete set of Jakarta EE 8 APIs including
+            <!-- JBoss distributes a complete set of Jakarta EE APIs including
                 a Bill of Materials (BOM). A BOM specifies the versions of a "stack" (or
                 a collection) of artifacts. We use this here so that we always get the correct
-                versions of artifacts. Here we use the wildfly-jakartaee-8.0-with-tools stack
-                (you can read this as the WildFly stack of the Jakarta EE 8 APIs, with some extras
-                tools for your project, such as Arquillian for testing) -->
+                versions of artifacts (you can read this as the WildFly stack of the Jakarta EE APIs,
+                with some extras tools for your project, such as Arquillian for testing) -->
             <dependency>
                 <groupId>org.wildfly.bom</groupId>
                 <artifactId>wildfly-ee-with-tools</artifactId>


### PR DESCRIPTION
Most archetypes don't use the "maven-surefire-plugin", but declare a version number property. Only the subsystem archetypes needs it. So I removed the unused properties.

Also, the dependency "org.wildfly.bom:wildfly-ee-with-tools" had an outdated comment, which still spoke of JakartaEE8. I copied the comment from the "getting-started" archetype.