### PR TITLE
Remove temporary workaround for arquillian-protocol-servlet-jakarta

### DIFF
--- a/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -166,16 +166,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
-            <!-- temporary overriding as the 1.9.1.Final version pulled by
-                 WildFly BOM does not exist.
-            -->
-            <version>10.0.0.Final</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-container-managed</artifactId>
             <scope>test</scope>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -166,16 +166,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-
-            <dependency>
-                <groupId>org.jboss.arquillian.protocol</groupId>
-                <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
-                <!-- temporary overriding as the 1.9.1.Final version pulled by
-                     WildFly BOM does not exist.
-                -->
-                <version>10.0.0.Final</version>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -217,16 +217,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
-            <!-- temporary overriding as the 1.9.1.Final version pulled by
-                 WildFly BOM does not exist.
-            -->
-            <version>10.0.0.Final</version>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 
     <build>


### PR DESCRIPTION
Removes a workaround that was introduced as part of #105

Since WildFly BOM 34.0.0.Final, the correct versions is declared for `org.jboss.arquillian.protocol:arquillian-protocol-servlet-jakarta`