### PR TITLE
arquillian.xml: use servlet protocol 6.0, cleanup

### DIFF
--- a/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/test/resources/arquillian.xml
+++ b/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/test/resources/arquillian.xml
@@ -2,25 +2,9 @@
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    JBoss, Home of Professional Open Source
-    Copyright 2017, Red Hat, Inc. and/or its affiliates, and individual
-    contributors by the @authors tag. See the copyright.txt in the
-    distribution for a full listing of individual contributors.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
--->
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://jboss.org/schema/arquillian
-    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+                                https://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <container default="true" qualifier="managed">
         <configuration>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/src/test/resources/arquillian.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/src/test/resources/arquillian.xml
@@ -1,26 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    JBoss, Home of Professional Open Source
-    Copyright 2017, Red Hat, Inc. and/or its affiliates, and individual
-    contributors by the @authors tag. See the copyright.txt in the
-    distribution for a full listing of individual contributors.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
--->
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://jboss.org/schema/arquillian
-    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+                                https://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <!-- Force the use of the Servlet 3.0 protocol with all containers, as it is the most mature -->
-    <defaultProtocol type="Servlet 3.0" />
+    <!-- Use the Servlet 6.0 protocol to communicate with the container -->
+    <defaultProtocol type="Servlet 6.0" />
 
     <!-- Uncomment to have test archives exported to the file system for inspection -->
     <!--<engine>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/test/resources/arquillian.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/test/resources/arquillian.xml
@@ -1,26 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    JBoss, Home of Professional Open Source
-    Copyright 2017, Red Hat, Inc. and/or its affiliates, and individual
-    contributors by the @authors tag. See the copyright.txt in the
-    distribution for a full listing of individual contributors.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
--->
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://jboss.org/schema/arquillian
-    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+                                https://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <!-- Force the use of the Servlet 5.0 protocol with all containers - it is the only supported version here -->
-    <defaultProtocol type="Servlet 5.0" />
+    <!-- Use the Servlet 6.0 protocol to communicate with the container -->
+    <defaultProtocol type="Servlet 6.0" />
 
     <!-- Uncomment to have test archives exported to the file system for inspection -->
     <!--<engine>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/test/resources/arquillian.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/test/resources/arquillian.xml
@@ -1,26 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    JBoss, Home of Professional Open Source
-    Copyright 2017, Red Hat, Inc. and/or its affiliates, and individual
-    contributors by the @authors tag. See the copyright.txt in the
-    distribution for a full listing of individual contributors.
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
--->
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://jboss.org/schema/arquillian
-    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+                                https://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <!-- Force the use of the Servlet 5.0 protocol with all containers - it is the only supported version here -->
-    <defaultProtocol type="Servlet 5.0" />
+    <!-- Use the Servlet 6.0 protocol to communicate with the container -->
+    <defaultProtocol type="Servlet 6.0" />
 
     <!-- Uncomment to have test archives exported to the file system for inspection -->
     <!--<engine>


### PR DESCRIPTION
Some cleanup in "arquillian.xml":

1. Switched the servlet protocol to "6.0" (though I don't think that it makes any difference: https://github.com/arquillian/arquillian-jakarta/blob/main/protocols/servlet-jakarta/src/main/java/org/jboss/arquillian/protocol/servlet5/v_6/ServletProtocol.java)
2. use a HTTPS url for the xsd
3. remove the license header