### PR TITLE
Switch ear ejb project to arquillian-junit5-container

### DIFF
--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/pom.xml
@@ -64,8 +64,8 @@
         <!-- Arquillian allows you to test enterprise code such as EJBs and
             Transactional(JTA) JPA from JUnit/TestNG -->
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
The ejb project as part of the ear archetype still defined "org.jboss.arquillian.junit:arquillian-junit-container" instead of the JUnit5 equivalent.
The ejb project has no unit tests, so I did not notice it.