### PR TITLE
Add dependency 'jakarta.servlet.jsp:jakarta.servlet.jsp-api' to web project pom

### DIFF
--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/pom.xml
@@ -82,6 +82,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- JSP API. Required by Eclipse in order to support taglibraries like JSTL. -->
+        <dependency>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Import the EJB API, we use provided scope as the API is included in WildFly / JBoss EAP -->
         <dependency>
             <groupId>jakarta.ejb</groupId>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -186,6 +186,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- JSP API. Required by Eclipse in order to support taglibraries like JSTL. -->
+        <dependency>
+            <groupId>jakarta.servlet.jsp</groupId>
+            <artifactId>jakarta.servlet.jsp-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- Import the EJB API, we use provided scope as the API is included in WildFly / JBoss EAP -->
         <dependency>
             <groupId>jakarta.ejb</groupId>


### PR DESCRIPTION
This dependency is required by the Eclipse JSP editor in order to resolve e.g. JSTL tags.

In order to use a JSTL tag, you first have to add the JSTL tablib to the pom.xml:

```xml
<dependency>
	<groupId>org.glassfish.web</groupId>
	<artifactId>jakarta.servlet.jsp.jstl</artifactId>
	<version>3.0.1</version>
	<scope>provided</scope>
</dependency>

<dependency>
	<groupId>jakarta.servlet.jsp.jstl</groupId>
	<artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
	<version>3.0.1</version>
	<scope>provided</scope>
</dependency>
```

Now you could use the taglib with this snippet:
```

<%@ taglib uri="jakarta.tags.core" prefix="c" %>
...
<c:if test="${...}">
```

Eclipse will report an error for the "c:if" tag: `The tag handler class for "c:if" (org.apache.taglibs.standard.tag.rt.core.IfTag) was not found on the Java Build Path`

Reason: the base class for all tags (`jakarta.servlet.jsp.tagext.TagSupport`) is found in artifact "jakarta.servlet.jsp:jakarta.servlet.jsp-api", which is not on the build path. This pull requests adds it.

As it is not obvious to conclude from the Eclipse error to the missing jar file, I hope it is reasonable to add the dependency to the archetype pom.