### PR TITLE
GettingStarted: switch to provisioning discovery, improve documentation

### DIFF
--- a/wildfly-getting-started-archetype/README.adoc
+++ b/wildfly-getting-started-archetype/README.adoc
@@ -12,32 +12,19 @@ and run the web application on the provisoned server so no manual installation
 is required.
 
 It is prepared for running Arquillian unit tests.
-More details can be found in the file "src/main/resources/archetype-resources/README.txt", which is end-user doc and added to the resulting project.
+More details can be found in the file "src/main/resources/archetype-resources/README.adoc", which is end-user doc and added to the resulting project.
 
 [[newwildflyversion]]
-== New WildFly version
-To update this archetype to a new WildFly version:
-In file "pom.xml":
+== New WildFly version and dependency updates
+The versions of all required dependencies are configured in the archetypes root project. When building the root pom, the file "src/main/resources-filtered/archetype-resources" is
+copied to "target/classes/archetype-resources", then all version variables are replaced with the values of the root pom, and the archetype artifact is built.
 
-* update the version
-* update to latest "org.jboss:jboss-parent" version found at https://repo.maven.apache.org/maven2/org/jboss/jboss-parent/
+So, to update this archetype to a new WildFly version, just update the version variables in the root pom, then run a build of the archetype root project.
 
-In file "src/main/resources/archetype-resources/pom.xml":
-
-* update the version property named "version.jboss.bom"
-* check whether dependencies have changed.
-* check the plugin versions and update if necessary:
-** wildfly-maven-plugin: https://repo.maven.apache.org/maven2/org/wildfly/plugins/wildfly-maven-plugin/
-** maven-compiler-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-compiler-plugin/
-** maven-surefire-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-surefire-plugin/
-** maven-failsafe-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-failsafe-plugin/
-** maven-war-plugin: https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-war-plugin/
-
-Also test whether the Arquillian unit test "SampleIT" still works, see below.
 
 [[build]]
 == Build
-To build the archetype, you need at least Java 17. Run this command:
+To build the archetype, you need at least Java 17. Run this command in the archetype root project:
 [source,options="nowrap"]
 ----
 $ mvn clean install
@@ -53,13 +40,7 @@ $ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sampleproject -Dv
 
 [[testing]]
 == Test the archetype
-After having built the archetype, check whether both profiles "arq-remote" and "arq-managed" work. This is done by using scripts found in the directory "testing".
-
-* Profile "arq-managed": set variable JBOSS_HOME, then execute "runtest_managed.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
-* Profile "arq-remote": start WildFly server, then execute "runtest_remote.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
-
-Both files create a project from the archetype (in "testing/arq-managed" or "testing/arq-remote"), copy an Arquillian unit test class and an EJB in this project, then build and deploy it to WildFly and execute
-the test using the Arquillian profile "arq-managed" or "arq-remote").
-
-After the test is executed, check the server log for error outputs. In case of success, the outputs "Test is invoked..." and "doTest is invoked..." will be printed in the server console.
+As part of building the archetype, Maven creates a project "basic" and launches a test run. This test run provisions a WildFly server using WildFly Glow. The sample
+war file is added the deployments. Then the server is started and tests are executed. As the archetype contains a "real" service and two test class (server side and client side),
+a full arquillian test run is performed during build, so no additional manual testing is required.
 

--- a/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-getting-started-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -211,21 +211,15 @@
                 </configuration>
             </plugin>
 
-            <!-- The WildFly plugin deploys your war to a local JBoss AS container -->
+            <!-- The WildFly plugin deploys your war to a local JBoss AS container and is configured here to provision a WildFly server. -->
             <plugin>
                 <groupId>org.wildfly.plugins</groupId>
                 <artifactId>wildfly-maven-plugin</artifactId>
                 <version>\${version.wildfly.maven.plugin}</version>
                 <configuration>
-                    <feature-packs>
-                        <feature-pack>
-                            <location>org.wildfly:wildfly-galleon-pack:\${version.wildfly.bom}</location>
-                        </feature-pack>
-                    </feature-packs>
-                    <layers>
-                        <!-- layers may be used to customize the server to provision-->
-                        <layer>cloud-server</layer>
-                    </layers>
+                    <discover-provisioning-info>
+                        <version>\${version.wildfly.bom}</version>
+                    </discover-provisioning-info>
                 </configuration>
                 <executions>
                     <execution>

--- a/wildfly-getting-started-archetype/src/main/resources/archetype-resources/README.adoc
+++ b/wildfly-getting-started-archetype/src/main/resources/archetype-resources/README.adoc
@@ -18,8 +18,34 @@ To run the application, you use Maven:
 mvn clean package
 ----
 
-Maven will compile the application, provision a WildFly server
+Maven will compile the application and provision a WildFly server.
 The WildFly server is created in `target/server` with the application deployed in it.
+
+Provisioning is done by using WildFly Glow discovery: Glow parses the deployment and adds all necessary WildFly features.
+Discovery is configured in "pom.xml" for the "wildfly-maven-plugin":
+
+----
+<configuration>
+	<discover-provisioning-info>
+		<version>${version.wildfly.bom}</version>
+	</discover-provisioning-info>
+</configuration>
+----
+
+You could also configure the WildFly Glow provisioning yourself:
+
+----
+<configuration>
+	<feature-packs>
+		<feature-pack>
+			<location>org.wildfly:wildfly-galleon-pack:${version.wildfly.bom}</location>
+		</feature-pack>
+	</feature-packs>
+	<layers>
+		<layer>cloud-server</layer>
+	</layers>
+</configuration>
+----
 
 == Running the application
 


### PR DESCRIPTION
Part one to resolve #145: use Glow auto discovery to provision the server in the GettingStarted archetype.

I copied the old way to define layers to the end user "Readme.adoc" that is part of the project generated from the archetype.

While updating it I noticed that the doc of the archetype project itself was copied from one of the other archetypes, but not all parts were updated. So this change is larger than I initially planned.

