### PR TITLE
WebApp: add a profile for provisioning the server

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -47,10 +47,16 @@ jobs:
     - name: Run Jakarta EE Webapp Archetype Tests
       run: |-
         echo "* Jakarta EE Webapp Archetype" >> $GITHUB_STEP_SUMMARY
-
         cd wildfly-jakartaee-webapp-archetype/testing
+
+        ./runtest_provision.sh $ARCHETYPE_VERSION
+        echo "  * :white_check_mark: Provisioned Server" >> $GITHUB_STEP_SUMMARY
+
         ./runtest_managed.sh $ARCHETYPE_VERSION
         echo "  * :white_check_mark: Managed Tests" >> $GITHUB_STEP_SUMMARY
+
+        ./runtest_provisioned.sh $ARCHETYPE_VERSION
+        echo "  * :white_check_mark: Provisioned Tests" >> $GITHUB_STEP_SUMMARY
 
         $JBOSS_HOME/bin/standalone.sh &
         until `$JBOSS_HOME/bin/jboss-cli.sh -c ":read-attribute(name=server-state)" 2> /dev/null | grep -q running`; do
@@ -88,4 +94,5 @@ jobs:
         rm -rf wildfly-jakartaee-ear-archetype/testing/arq-managed
         rm -rf wildfly-jakartaee-webapp-archetype/testing/arq-remote
         rm -rf wildfly-jakartaee-webapp-archetype/testing/arq-managed
+        rm -rf wildfly-jakartaee-webapp-archetype/testing/arq-provisioned
         rm -rf wildfly-subsystem-archetype/testing/example-subsystem

--- a/wildfly-jakartaee-webapp-archetype/README.adoc
+++ b/wildfly-jakartaee-webapp-archetype/README.adoc
@@ -6,6 +6,7 @@ WildFly archetype for blank WAR project
 
 This archetype creates a blank WAR project.
 It is prepared for running Arquillian unit tests.
+Optionally, it can provision a WildFly server.
 More details can be found in the file "src/main/resources/archetype-resources/README.txt", which is end-user doc and added to the resulting project.
 
 [[newwildflyversion]]
@@ -31,13 +32,18 @@ $ mvn archetype:generate -DgroupId=my.project.org -DartifactId=sampleproject -Dv
 
 [[testing]]
 ==== Test the archetype
-After having built the archetype, check whether both profiles "arq-remote" and "arq-managed" work. This is done by using scripts found in the directory "testing".
+After having built the archetype, check whether all four profiles "arq-remote", "arq-managed", "provision" and "arq-provisioned" work. This is done by using scripts found in the directory "testing".
+
+The four profiles are executed as part of the Github CI.
 
 * Profile "arq-managed": set variable JBOSS_HOME, then execute "runtest_managed.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
 * Profile "arq-remote": start WildFly server, then execute "runtest_remote.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
+* Profile "provision": execute "runtest_provision.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
+* Profile "arq-provisioned": execute "runtest_provisioned.bat/.sh <archetypeVersion>" (replace "<archetypeVersion>" with the current archetype version)
 
-Both files create a project from the archetype (in "testing/arq-managed" or "testing/arq-remote"), copy an Arquillian unit test class and an EJB in this project, then build and deploy it to WildFly and execute
-the test using the Arquillian profile "arq-managed" or "arq-remote").
-
+The three "arq-....bat/.sh" files create a project from the archetype (in "testing/arq-managed", "testing/arq-remote", "testing/provision" or "testing/arq-provisioned"),
+copy an Arquillian unit test class and an EJB in this project, then build and deploy it to WildFly and execute the test using the Arquillian profile
+"arq-managed", "arq-remote" or "arq-provisioned").
 After the test is executed, check the server log for error outputs. In case of success, the outputs "Test is invoked..." and "doTest is invoked..." will be printed in the server console.
 
+The "provison.bat/.sh" files just builds the project and provisions a server.

--- a/wildfly-jakartaee-webapp-archetype/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/pom.xml
@@ -20,7 +20,8 @@
     <packaging>maven-archetype</packaging>
 
     <name>WildFly Archetypes: Jakarta EE Webapp</name>
-    <description>An archetype that generates a starter Jakarta EE project for JBoss WildFly. The project is a WAR archive. It is prepared for Arquillian driven unit tests.</description>
+    <description>An archetype that generates a starter Jakarta EE project for JBoss WildFly. The project is a WAR archive. It is prepared for Arquillian driven unit tests.
+	Optionally, a "ready to run your app" provisioned WildFly server can be created using WildFly Glow.</description>
 
     <build>
         <resources>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources-filtered/archetype-resources/pom.xml
@@ -328,6 +328,121 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <!-- This profile will build the project and create a provisioned WildFly server in "target/server" of the war project.
+                 The provisioned server contains the war application of this project.
+                 The profile will not execute arquillian tests.
+                 Run with: mvn clean verify -provision -->
+            <id>provision</id>
+            <build>
+                <plugins>
+                    <!-- The WildFly Maven plugin is executed during the "package" goal and provisions a WildFly server. -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>\${version.wildfly.maven.plugin}</version>
+                        <configuration>
+                            <discover-provisioning-info>
+                                <version>\${version.wildfly.bom}</version>
+                                <!-- "persistence.xml" uses "java:comp/DefaultDataSource".
+                                     We tell Glow to create a H2 database similar to the one defined in the full WildFly download. -->
+                                <add-ons>
+                                    <add-on>h2-database:default</add-on>
+                                </add-ons>
+                            </discover-provisioning-info>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <!-- The "goal" must be "package" here so that the server is created. -->
+                                    <goal>package</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>\${version.failsafe.plugin}</version>
+                        <configuration>
+                            <!--Don't execute arquillian tests: -->
+                            <skipTests>true</skipTests>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <!-- An optional Arquillian testing profile that provisions a WildFly server containing your app and executes tests in this instance.
+                 The provisioned server does not contain the war application of this project, so that Arquillian can deploy the application enriched with server side tests.
+                 This profile will start a new WildFly / JBoss EAP instance, and execute the test, shutting it down when done.
+                 Run with: mvn clean verify -Parq-provisioned -->
+            <id>arq-provisioned</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <!-- The WildFly Maven plugin is executed during the "package" goal and provisions a WildFly server. -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <version>\${version.wildfly.maven.plugin}</version>
+                        <configuration>
+                            <discover-provisioning-info>
+                                <version>\${version.wildfly.bom}</version>
+                                <!-- "persistence.xml" uses "java:comp/DefaultDataSource".
+                                     We tell Glow to create a H2 database similar to the one defined in the full WildFly download. -->
+                                <add-ons>
+                                    <add-on>h2-database:default</add-on>
+                                </add-ons>
+                            </discover-provisioning-info>
+                            <!--Don't add the war application as deployment to the provisioned server: -->
+                            <skipDeployment>true</skipDeployment>
+                            <!--Use a name that differs from the server name of the "provision" profile in order to avoid conflicts if this profile was run before
+                                and a provisioned server already exists in the default location that contains the deployment.
+                                The server is created in a subdir in "target". -->
+                            <provisioningDir>server_arquillian</provisioningDir>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <!-- The "goal" must be "package" here so that the server is created. -->
+                                    <goal>package</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>\${version.failsafe.plugin}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- Configuration for Arquillian: -->
+                            <systemPropertyVariables>
+                                <!-- Defines the container qualifier in "arquillian.xml" -->
+                                <arquillian.launch>provisioned</arquillian.launch>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/README.txt
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/README.txt
@@ -15,12 +15,48 @@ a persistence unit "${rootArtifactId}PersistenceUnit" which uses the JakartaEE d
 In production environment, you should define a database in WildFly config and point to this database
 in "persistence.xml".
 
+If you change the datasource name and use provisioning (profile "provision" or "arq-provisioned", see below),
+you have to update the provisioning config.
+
 If you don't use entity beans, you can delete "persistence.xml".
 ==========================
 
 Jakarta Faces:
 The web application is prepared for Jakarta Faces 4.0 by bundling an empty "faces-config.xml" in "src/main/webapp/WEB-INF".
 In case you don't want to use Jakarta Faces, simply delete this file and "src/main/webapp/beans.xml".
+
+==========================
+Provisioning:
+The project defines two profiles "provision" and "arq-provisioned" that create a provisioned WildFly server (in "target/server" or "target/server_arquillian")
+by auto discovering features necessary to run this application.
+
+The profile "provision" is meant to build a server that contains this web application as deployment.
+The profile "arq-provisioned" also builds a server, then runs the arquillian tests. This profile does not add the deployment, so that the arquillian
+tests can deploy the app themselves enriched with additional test classes.
+
+As "persistence.xml" uses the datasource "java:comp/DefaultDataSource", Glow must be configured to create 
+the datasource in the WildFly server config. Currently, the default H2 datasource is configured:
+
+    <add-ons>
+        <add-on>h2-database:default</add-on>
+    </add-ons>
+
+If you change the datasource name in "persistence.xml" or want to use a different datasource, you have to change the Glow configuration
+so that it creates the necessary snippets in the WildFly config.
+
+When using a provisioned server, you would probably deploy the app as root application, as the server provides only one application -
+no need to have a context path.
+You could change this by changing the "finalName" to "ROOT":
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        ...
+    </build>
+
+If you do so and use integration tests, you also have to change this line of code in "SampleIT.java" that opens the war file and create a new war file
+with arquillian test classes. It now should open "Root.war":
+
+        File f = new File("./target/${rootArtifactId}.war");
 ==========================
 
 Testing:
@@ -28,8 +64,8 @@ This sample is prepared for running JUnit5 unit tests with the Arquillian framew
 
 The configuration can be found in "${rootArtifactId}/pom.xml":
 
-Three profiles are defined:
--"default": no integration tests are executed.
+Five profiles are defined:
+-"default" and "provision": no integration tests are executed.
 -"arq-remote": you have to start a WildFly server on your machine. The tests are executed by deploying
  the application to this server.
  Here the "maven-failsafe-plugin" is enabled so that integration tests can be run.
@@ -39,18 +75,31 @@ Three profiles are defined:
  Instead of using this environment variable, you can also define the path in "arquillian.xml".
  Here the "maven-failsafe-plugin" is enabled so that integration tests can be run.
  Run maven with these arguments: "clean verify -Parq-managed"
+-"arq-provisioned": the tests are executed by deploying the application to the
+ server that is created during the provisioning step (in "target/server").
 
 The Arquillian test runner is configured with the file "src/test/resources/arquillian.xml"
 (duplicated in EJB and WEB project, depending where your tests are placed).
-The profile "arq-remote" uses the container qualifier "remote" in this file.
-The profile "arq-managed" uses the container qualifier "managed" in this file.
+-The profile "arq-remote" uses the container qualifier "remote" in this file.
+-The profile "arq-managed" uses the container qualifier "managed" in this file.
+-The profile "arq-provisioned" uses the container qualifier "provisioned" in this file, which sets
+JBOSS_HOME to "target/server_arquillian".
 
 The project contains an integration test "SampleIT" which shows how to create the deployable WAR file using the ShrinkWrap API.
 You can delete this test file if no tests are necessary.
 
 Why integration tests instead of the "maven-surefire-plugin" testrunner?
+There are two reasons for this:
+Reason 1:
 The Arquillian test runner deploys the WAR file to the WildFly server and thus you have to build it yourself with the ShrinkWrap API.
 The goal "verify" (which triggers the maven-surefire-plugin) is executed later in the maven build lifecyle than the "test" goal so that the target
 artifact ("${rootArtifactId}.war") is already built. You can build
 the final WAR by including those files. The "maven-surefire-plugin" is executed before the WAR file
-are created, so this WAR files would have to be built in the "@Deployment" method, too.
+is created, so this WAR files would have to be built in the "@Deployment" method, too.
+
+Reason 2:
+Basically, you can run Arquillian tests using the "maven-surefire-plugin". But due to the structure of the project,
+this does not work here. The project provides several profiles, each defines a different way for Arquillian to connect to a WildFly server and
+deploy the test application. The "default" profile thus does not have any Arquillian configuration.
+As it also does not attach the "maven-failsafe-plugin" to any goal, no integration tests are executed and Arquillian is not invoked.
+The "maven-surefire-plugin" test execution is automatically activated, and those test would fail here as no server for Arquillian is configured.

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/test/resources/arquillian.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/test/resources/arquillian.xml
@@ -32,4 +32,12 @@
             <property name="password">admin</property> -->
         </configuration>
     </container>
+
+    <!-- Example configuration for a WildFly server provisioned by WildFly Glow. The server is found in the subdir "target/server_arquillian".
+         We defined a custom "provisioningDir" for the Arquillian tests. -->
+    <container qualifier="provisioned">
+        <configuration>
+            <property name="jbossHome">target/server_arquillian</property>
+        </configuration>
+    </container>
 </arquillian>

--- a/wildfly-jakartaee-webapp-archetype/testing/.gitignore
+++ b/wildfly-jakartaee-webapp-archetype/testing/.gitignore
@@ -1,2 +1,4 @@
 /arq-managed
 /arq-remote
+/arq-provisioned
+/provision

--- a/wildfly-jakartaee-webapp-archetype/testing/runtest_provision.bat
+++ b/wildfly-jakartaee-webapp-archetype/testing/runtest_provision.bat
@@ -1,0 +1,44 @@
+@REM Creates a project from the archetype and creates a provisioned server
+@REM using the profile "provision".
+@REM Prerequesites: none.
+@REM The current archetype version must be the first argument to the batch file call.
+
+@echo off
+
+@if "%1" == "" (
+  echo Archetype version must be first argument to the call to the batch file.
+  set /p archetypeVersion=Please enter archetype version:
+) else (
+  set archetypeVersion=%1
+)
+
+if exist provision (
+  @ECHO delete old test project
+  rmdir /S /Q provision
+)
+@REM if directory still exists then fail
+if exist provision (
+  @echo [ERROR] directory 'provision' could not be deleted
+  goto :exit
+)
+
+@ECHO creating test project directory
+mkdir provision
+cd provision
+
+@ECHO generate project from archetype.
+call mvn archetype:generate -DarchetypeCatalog=local -DgroupId=foo.bar -DartifactId=multi -Dversion=0.1-SNAPSHOT -Dpackage=foo.bar.multi -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-webapp-archetype -DarchetypeVersion=%archetypeVersion% -DinteractiveMode=false
+if %ERRORLEVEL% NEQ 0 (
+  @echo [ERROR] Maven project creation failed. Errorlevel: %ERRORLEVEL%
+  cd..
+  goto :exit
+)
+
+cd multi
+@ECHO run test
+call mvn verify -Pprovision
+cd ..\..
+
+
+
+:exit

--- a/wildfly-jakartaee-webapp-archetype/testing/runtest_provision.sh
+++ b/wildfly-jakartaee-webapp-archetype/testing/runtest_provision.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Creates a project from the archetype and creates a provisioned server
+# using the profile "provision".
+# Prerequesites: none.
+# The current archetype version must be the first argument to the batch file call.
+
+if [ -z "$1" ]
+  then
+    echo Archetype version must be first argument to the call to the batch file.
+    read -p "Please enter archetype version: " archetypeVersion
+  else
+    archetypeVersion=$1
+fi
+
+if [ -d "provision" ]; then
+  echo "delete old test project"
+  rm -rf provision
+fi
+
+
+# if directory still exists then fail
+if [ -d "provision" ]; then
+  echo "[ERROR] directory 'provision' could not be deleted"
+  exit 1
+fi
+
+echo "creating test project directory"
+mkdir provision
+cd provision
+
+echo "generate project from archetype."
+mvn archetype:generate -DarchetypeCatalog=local -DgroupId=foo.bar -DartifactId=multi -Dversion=0.1-SNAPSHOT -Dpackage=foo.bar.multi -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-webapp-archetype -DarchetypeVersion=$archetypeVersion -DinteractiveMode=false
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "[ERROR] Maven project creation failed. Errorcode: $retVal"
+  cd ..
+  exit $retVal
+fi
+
+cd multi
+echo "run test"
+mvn verify -Pprovision
+retVal=$?
+cd ../..
+exit $retVal

--- a/wildfly-jakartaee-webapp-archetype/testing/runtest_provisioned.bat
+++ b/wildfly-jakartaee-webapp-archetype/testing/runtest_provisioned.bat
@@ -1,0 +1,50 @@
+@REM Creates a project from the archetype, copies some additional source files and runs an integration test
+@REM using the profile "arq-provisioned".
+@REM Prerequesites: none, the tests are run on a WildFly server that is created as part of the build process.
+@REM The current archetype version must be the first argument to the batch file call.
+
+@echo off
+
+@if "%1" == "" (
+  echo Archetype version must be first argument to the call to the batch file.
+  set /p archetypeVersion=Please enter archetype version:
+) else (
+  set archetypeVersion=%1
+)
+
+if exist arq-provisioned (
+  @ECHO delete old test project
+  rmdir /S /Q arq-provisioned
+)
+@REM if directory still exists then fail
+if exist arq-provisioned (
+  @echo [ERROR] directory 'arq-provisioned' could not be deleted
+  goto :exit
+)
+
+@ECHO creating test project directory
+mkdir arq-provisioned
+cd arq-provisioned
+
+@ECHO generate project from archetype.
+call mvn archetype:generate -DarchetypeCatalog=local -DgroupId=foo.bar -DartifactId=multi -Dversion=0.1-SNAPSHOT -Dpackage=foo.bar.multi -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-webapp-archetype -DarchetypeVersion=%archetypeVersion% -DinteractiveMode=false
+if %ERRORLEVEL% NEQ 0 (
+  @echo [ERROR] Maven project creation failed. Errorlevel: %ERRORLEVEL%
+  cd..
+  goto :exit
+)
+
+@ECHO copy additional files required for test.
+copy ..\additionalfiles\TestBean.java .\multi\src\main\java\foo\bar\multi\
+copy ..\additionalfiles\TestLocal.java .\multi\src\main\java\foo\bar\multi\
+copy ..\additionalfiles\TestRemote.java .\multi\src\main\java\foo\bar\multi\
+copy ..\additionalfiles\ArchetypeIT.java .\multi\src\test\java\foo\bar\multi\test\
+
+cd multi
+@ECHO run test
+call mvn verify -Parq-provisioned
+cd ..\..
+
+
+
+:exit

--- a/wildfly-jakartaee-webapp-archetype/testing/runtest_provisioned.sh
+++ b/wildfly-jakartaee-webapp-archetype/testing/runtest_provisioned.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Creates a project from the archetype, copies some additional source files and runs an integration test
+# using the profile "arq-provisioned".
+# Prerequesites: none, the tests are run on a WildFly server that is created as part of the build process.
+# The current archetype version must be the first argument to the batch file call.
+
+if [ -z "$1" ]
+  then
+    echo Archetype version must be first argument to the call to the batch file.
+    read -p "Please enter archetype version: " archetypeVersion
+  else
+    archetypeVersion=$1
+fi
+
+if [ -d "arq-provisioned" ]; then
+  echo "delete old test project"
+  rm -rf arq-provisioned
+fi
+
+
+# if directory still exists then fail
+if [ -d "arq-provisioned" ]; then
+  echo "[ERROR] directory 'arq-provisioned' could not be deleted"
+  exit 1
+fi
+
+echo "creating test project directory"
+mkdir arq-provisioned
+cd arq-provisioned
+
+echo "generate project from archetype."
+mvn archetype:generate -DarchetypeCatalog=local -DgroupId=foo.bar -DartifactId=multi -Dversion=0.1-SNAPSHOT -Dpackage=foo.bar.multi -DarchetypeGroupId=org.wildfly.archetype -DarchetypeArtifactId=wildfly-jakartaee-webapp-archetype -DarchetypeVersion=$archetypeVersion -DinteractiveMode=false
+retVal=$?
+if [ $retVal -ne 0 ]; then
+  echo "[ERROR] Maven project creation failed. Errorcode: $retVal"
+  cd ..
+  exit $retVal
+fi
+
+
+echo "copy additional files required for test."
+cp ../additionalfiles/TestBean.java ./multi/src/main/java/foo/bar/multi/
+cp ../additionalfiles/TestLocal.java ./multi/src/main/java/foo/bar/multi/
+cp ../additionalfiles/TestRemote.java ./multi/src/main/java/foo/bar/multi/
+cp ../additionalfiles/ArchetypeIT.java ./multi/src/test/java/foo/bar/multi/test/
+
+cd multi
+echo "run test"
+mvn verify -Parq-provisioned
+retVal=$?
+cd ../..
+exit $retVal


### PR DESCRIPTION
Part two to resolve #145: I added a profile "arq-provisioned" to the webapp archetype that provisions a server and runs the arquillian tests using this server.

This pull request is a request for comments ;-).

The provisioning profile required a change to the way the arquillian test deployment is created: as the provisioned server already contains the war file, the test deployment war file must have a different name - I added suffix "Tests", e.g. "MyApplicationTests.war".

Probably, it would be more reasonable to name the deployed app "Root.war" in case of provisioning, but this would probably conflict with the old school use case to develop an app without knowing how it will be deployed. So I would prefer to keep the name as is - I added hints to the end user "Readme.txt" to change the deployment name depending on the use case.