### PR TITLE
Switch to archetype plugin 3.4.1, avoid false warning when creating project from archetype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <version.ear.plugin>3.4.0</version.ear.plugin>
         <version.ejb.plugin>3.2.1</version.ejb.plugin>
         <version.antrun.plugin>3.1.0</version.antrun.plugin>
+        <version.archetype.plugin>3.4.1</version.archetype.plugin>
 
         <maven.compiler.release>17</maven.compiler.release>
 
@@ -160,12 +161,11 @@
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>${version.antrun.plugin}</version>
                 </plugin>
-                <!--Workaround: downgrade maven-archetype-plugin to 3.1.2, as 3.2.1 from jboss-parent 40 prints a warning when creating a project from this archetype.
-                    For details see https://github.com/wildfly/wildfly-archetypes/issues/51 -->
+                <!--This plugin is needed for building the archetypes, but not used inside the archetypes. -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-archetype-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>${version.archetype.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -54,9 +54,17 @@
                 </fileSet>
                 <fileSet encoding="UTF-8" packaged="true" filtered="true">
                     <directory>src/test/java</directory>
+                    <!-- Workaround for https://github.com/wildfly/wildfly-archetypes/issues/51 - adding a "include" filter fixes a false warning -->
+                    <includes>
+                        <include>**/*.java</include>
+                    </includes>
                 </fileSet>
                 <fileSet encoding="UTF-8">
                     <directory>src/main/webapp</directory>
+                    <!-- Same workaround: the directory contains files, so include all xml files. -->
+                    <includes>
+                        <include>**/*.xml</include>
+                    </includes>
                 </fileSet>
                 <fileSet encoding="UTF-8" filtered="true">
                     <directory>src/test/resources</directory>

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -29,9 +29,17 @@
         </fileSet>
         <fileSet encoding="UTF-8" packaged="true" filtered="true">
             <directory>src/test/java</directory>
+            <!-- Workaround for https://github.com/wildfly/wildfly-archetypes/issues/51 - adding a "include" filter fixes a false warning -->
+            <includes>
+                <include>**/*.java</include>
+            </includes>
         </fileSet>
         <fileSet encoding="UTF-8">
             <directory>src/main/webapp</directory>
+            <!-- Same workaround: the directory contains files, so include all xml files. -->
+            <includes>
+                <include>**/*.xml</include>
+            </includes>
         </fileSet>
         <fileSet encoding="UTF-8" filtered="true">
             <!--"persistence.xml" -->

--- a/wildfly-subsystem-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/wildfly-subsystem-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -31,12 +31,16 @@
 
         <fileSet filtered="true" packaged="true" encoding="UTF-8">
             <directory>src/main/java</directory>
+            <!-- Workaround for https://github.com/wildfly/wildfly-archetypes/issues/51 - adding a "include" filter fixes a false warning -->
+            <includes>
+                <include>**/*.java</include>
+            </includes>
         </fileSet>
         <fileSet encoding="UTF-8" packaged="true" filtered="true">
             <directory>src/test/java</directory>
-        </fileSet>
-        <fileSet encoding="UTF-8">
-            <directory>src/main/webapp</directory>
+            <includes>
+                <include>**/*.java</include>
+            </includes>
         </fileSet>
         <fileSet encoding="UTF-8" filtered="true" packaged="true">
             <!--"LocalDescriptions.properties" is placed in a package directory structure-->


### PR DESCRIPTION
I think I finally found a workaround to resolve the warning from #51 and switch to recent versions of the maven archetype plugin.

In "archetype-metadata.xml" I had defined fileSets for e.g. "src/test/java" or "src/main/webapp", and those directories also contained java files files or deployment descriptors:

```xml
        <module id="web" dir="web" name="web">
            <fileSets>
                ...
                <fileSet encoding="UTF-8" packaged="true" filtered="true">
                    <directory>src/test/java</directory>
                </fileSet>
                <fileSet encoding="UTF-8">
                    <directory>src/main/webapp</directory>
                </fileSet>
                ...
            </fileSets>
        </module>
```
This caused the warnings.

My workaround: I added a "includes" filter for all those directories:

```xml
        <module id="web" dir="web" name="web">
            <fileSets>
                ..
                <fileSet encoding="UTF-8" packaged="true" filtered="true">
                    <directory>src/test/java</directory>
                    <includes>
                        <include>**/*.java</include>
                    </includes>
                </fileSet>
                <fileSet encoding="UTF-8">
                    <directory>src/main/webapp</directory>
                    <includes>
                        <include>**/*.xml</include>
                    </includes>
                </fileSet>
                ...
            </fileSets>
        </module>
```

Now the warning is gone. Feels like a hack...

This commit supersedes #180
Also, in the subsystem archetype, there was a fileSet definition copied from one of the other archetypes, I removed it.