### PR TITLE
WildFly 40: Upgrade all deployment descriptors to JakartaEE11

### DIFF
--- a/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
+++ b/wildfly-getting-started-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
@@ -2,11 +2,11 @@
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 <?xml version="1.0" encoding="UTF-8"?>
-<beans version="4.0"
+<beans version="4.1"
    xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
       https://jakarta.ee/xml/ns/jakartaee
-      https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+      https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
    bean-discovery-mode="annotated">
 
    <!-- This descriptor configures Context and Dependeny Injection (CDI).

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ear/pom.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ear/pom.xml
@@ -37,7 +37,7 @@
                 <version>${version.ear.plugin}</version>
                 <configuration>
                     <!-- Tell Maven we are using Jakarta EE -->
-                    <version>10</version>
+                    <version>11</version>
                     <!-- Use Jakarta EE ear libraries as needed. Jakarta EE ear libraries
                         are in easy way to package any libraries needed in the ear, and automatically
                         have any modules (EJB-JARs and WARs) use them -->

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/src/main/resources/META-INF/persistence.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/ejb/src/main/resources/META-INF/persistence.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="3.0"
+<persistence version="3.2"
    xmlns="https://jakarta.ee/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
         https://jakarta.ee/xml/ns/persistence
-        https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd">
+        https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd">
    <persistence-unit name="${rootArtifactId}PersistenceUnit">
       <!-- If you are running in a production environment, add a managed
          data source, this configuration uses the JakartaEE default data source is just for development and testing! -->

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/main/webapp/WEB-INF/beans.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/main/webapp/WEB-INF/beans.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans version="4.0"
+<beans version="4.1"
    xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
       https://jakarta.ee/xml/ns/jakartaee
-      https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+      https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
    bean-discovery-mode="annotated">
 
    <!-- This descriptor configures Context and Dependeny Injection (CDI).

--- a/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/main/webapp/WEB-INF/faces-config.xml
+++ b/wildfly-jakartaee-ear-archetype/src/main/resources/archetype-resources/web/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <!-- This file is not required if you don't need any extra configuration. -->
-<faces-config version="4.0" xmlns="https://jakarta.ee/xml/ns/jakartaee"
+<faces-config version="4.1" xmlns="https://jakarta.ee/xml/ns/jakartaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
         https://jakarta.ee/xml/ns/jakartaee
-        https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd">
+        https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd">
 
    <!-- This descriptor activates the Jakarta Faces Servlet -->
 

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/persistence.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/resources/META-INF/persistence.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="3.0"
+<persistence version="3.2"
    xmlns="https://jakarta.ee/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
         https://jakarta.ee/xml/ns/persistence
-        https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd">
+        https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd">
    <persistence-unit name="${rootArtifactId}PersistenceUnit">
       <!-- If you are running in a production environment, add a managed
          data source, this configuration uses the JakartaEE default data source is just for development and testing! -->

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/beans.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans version="4.0"
+<beans version="4.1"
    xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
       https://jakarta.ee/xml/ns/jakartaee
-      https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+      https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
    bean-discovery-mode="annotated">
 
    <!-- This descriptor configures Context and Dependeny Injection (CDI).

--- a/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/faces-config.xml
+++ b/wildfly-jakartaee-webapp-archetype/src/main/resources/archetype-resources/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <!-- This file is not required if you don't need any extra configuration. -->
-<faces-config version="4.0" xmlns="https://jakarta.ee/xml/ns/jakartaee"
+<faces-config version="4.1" xmlns="https://jakarta.ee/xml/ns/jakartaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
         https://jakarta.ee/xml/ns/jakartaee
-        https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_0.xsd">
+        https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_4_1.xsd">
 
    <!-- This descriptor activates the Jakarta Faces Servlet -->
 


### PR DESCRIPTION
As WildFly 40 brings JakartaEE11 by default, I updated all deployment descriptors in the archetypes to the new version.

Keeping this as a draft as long as WildFly 40 is not released, but requesting comments.